### PR TITLE
Add Name to DistLocker and use it for subtests

### DIFF
--- a/locks.go
+++ b/locks.go
@@ -17,8 +17,6 @@ type DistLocker interface {
 	Lock(ctx context.Context) error
 	// Unlock unlocks the previously successfully locked lock.
 	Unlock(ctx context.Context) error
-	// Name of the lock
-	Name() string
 }
 
 // LockNoop is a no-op implementation of the DistLocker interface.
@@ -29,10 +27,6 @@ type LockNoop struct {
 // NewLockNoop creates a new LockNoop.
 func NewLockNoop() *LockNoop {
 	return &LockNoop{}
-}
-
-func (n LockNoop) Name() string {
-	return "LockNoop"
 }
 
 // Lock imitates locking.
@@ -59,10 +53,6 @@ type LockEtcd struct {
 // NewLockEtcd creates a new instance of LockEtcd.
 func NewLockEtcd(cli *clientv3.Client, prefix string, logger Logger) *LockEtcd {
 	return &LockEtcd{cli: cli, prefix: prefix, logger: logger}
-}
-
-func (l *LockEtcd) Name() string {
-	return "LockEtcd"
 }
 
 // Lock creates a new session-based lock in etcd and locks it.
@@ -96,10 +86,6 @@ func NewLockConsul(lock *api.Lock) *LockConsul {
 	return &LockConsul{lock: lock}
 }
 
-func (l *LockConsul) Name() string {
-	return "LockConsul"
-}
-
 // Lock locks the lock in Consul.
 func (l *LockConsul) Lock(ctx context.Context) error {
 	_, err := l.lock.Lock(ctx.Done())
@@ -119,10 +105,6 @@ type LockZookeeper struct {
 // NewLockZookeeper creates a new instance of LockZookeeper.
 func NewLockZookeeper(lock *zk.Lock) *LockZookeeper {
 	return &LockZookeeper{lock: lock}
-}
-
-func (l *LockZookeeper) Name() string {
-	return "LockZookeeper"
 }
 
 // Lock locks the lock in Zookeeper.
@@ -146,10 +128,6 @@ func NewLockRedis(pool redsyncredis.Pool, mutexName string) *LockRedis {
 	rs := redsync.New(pool)
 	mutex := rs.NewMutex(mutexName)
 	return &LockRedis{mutex: mutex}
-}
-
-func (l *LockRedis) Name() string {
-	return "LockRedis"
 }
 
 // Lock locks the lock in Redis.

--- a/locks.go
+++ b/locks.go
@@ -17,6 +17,8 @@ type DistLocker interface {
 	Lock(ctx context.Context) error
 	// Unlock unlocks the previously successfully locked lock.
 	Unlock(ctx context.Context) error
+	// Name of the lock
+	Name() string
 }
 
 // LockNoop is a no-op implementation of the DistLocker interface.
@@ -27,6 +29,10 @@ type LockNoop struct {
 // NewLockNoop creates a new LockNoop.
 func NewLockNoop() *LockNoop {
 	return &LockNoop{}
+}
+
+func (n LockNoop) Name() string {
+	return "LockNoop"
 }
 
 // Lock imitates locking.
@@ -53,6 +59,10 @@ type LockEtcd struct {
 // NewLockEtcd creates a new instance of LockEtcd.
 func NewLockEtcd(cli *clientv3.Client, prefix string, logger Logger) *LockEtcd {
 	return &LockEtcd{cli: cli, prefix: prefix, logger: logger}
+}
+
+func (l *LockEtcd) Name() string {
+	return "LockEtcd"
 }
 
 // Lock creates a new session-based lock in etcd and locks it.
@@ -86,6 +96,10 @@ func NewLockConsul(lock *api.Lock) *LockConsul {
 	return &LockConsul{lock: lock}
 }
 
+func (l *LockConsul) Name() string {
+	return "LockConsul"
+}
+
 // Lock locks the lock in Consul.
 func (l *LockConsul) Lock(ctx context.Context) error {
 	_, err := l.lock.Lock(ctx.Done())
@@ -105,6 +119,10 @@ type LockZookeeper struct {
 // NewLockZookeeper creates a new instance of LockZookeeper.
 func NewLockZookeeper(lock *zk.Lock) *LockZookeeper {
 	return &LockZookeeper{lock: lock}
+}
+
+func (l *LockZookeeper) Name() string {
+	return "LockZookeeper"
 }
 
 // Lock locks the lock in Zookeeper.
@@ -128,6 +146,10 @@ func NewLockRedis(pool redsyncredis.Pool, mutexName string) *LockRedis {
 	rs := redsync.New(pool)
 	mutex := rs.NewMutex(mutexName)
 	return &LockRedis{mutex: mutex}
+}
+
+func (l *LockRedis) Name() string {
+	return "LockRedis"
 }
 
 // Lock locks the lock in Redis.

--- a/locks_test.go
+++ b/locks_test.go
@@ -23,22 +23,24 @@ func (s *LimitersTestSuite) TestDistLockers() {
 	locks1 := s.distLockers(false)
 	locks2 := s.distLockers(false)
 	for k := 0; k < len(locks1); k++ {
-		var shared int
-		rounds := 6
-		sleep := time.Millisecond * 50
-		for i := 0; i < rounds; i++ {
-			wg := sync.WaitGroup{}
-			wg.Add(2)
-			go func(k int) {
-				defer wg.Done()
-				s.useLock(locks1[k], &shared, sleep)
-			}(k)
-			go func(k int) {
-				defer wg.Done()
-				s.useLock(locks2[k], &shared, sleep)
-			}(k)
-			wg.Wait()
-		}
-		s.Equal(rounds*2, shared)
+		s.Run(locks1[k].Name(), func() {
+			var shared int
+			rounds := 6
+			sleep := time.Millisecond * 50
+			for i := 0; i < rounds; i++ {
+				wg := sync.WaitGroup{}
+				wg.Add(2)
+				go func(k int) {
+					defer wg.Done()
+					s.useLock(locks1[k], &shared, sleep)
+				}(k)
+				go func(k int) {
+					defer wg.Done()
+					s.useLock(locks2[k], &shared, sleep)
+				}(k)
+				wg.Wait()
+			}
+			s.Equal(rounds*2, shared)
+		})
 	}
 }

--- a/locks_test.go
+++ b/locks_test.go
@@ -22,23 +22,23 @@ func (s *LimitersTestSuite) useLock(lock limiters.DistLocker, shared *int, sleep
 func (s *LimitersTestSuite) TestDistLockers() {
 	locks1 := s.distLockers(false)
 	locks2 := s.distLockers(false)
-	for k := 0; k < len(locks1); k++ {
-		s.NotEmpty(locks1[k].Name())
-		s.Run(locks1[k].Name(), func() {
+	for name := range locks1 {
+		s.NotEmpty(name)
+		s.Run(name, func() {
 			var shared int
 			rounds := 6
 			sleep := time.Millisecond * 50
 			for i := 0; i < rounds; i++ {
 				wg := sync.WaitGroup{}
 				wg.Add(2)
-				go func(k int) {
+				go func(name string) {
 					defer wg.Done()
-					s.useLock(locks1[k], &shared, sleep)
-				}(k)
-				go func(k int) {
+					s.useLock(locks1[name], &shared, sleep)
+				}(name)
+				go func(name string) {
 					defer wg.Done()
-					s.useLock(locks2[k], &shared, sleep)
-				}(k)
+					s.useLock(locks2[name], &shared, sleep)
+				}(name)
 				wg.Wait()
 			}
 			s.Equal(rounds*2, shared)

--- a/locks_test.go
+++ b/locks_test.go
@@ -23,6 +23,7 @@ func (s *LimitersTestSuite) TestDistLockers() {
 	locks1 := s.distLockers(false)
 	locks2 := s.distLockers(false)
 	for k := 0; k < len(locks1); k++ {
+		s.NotEmpty(locks1[k].Name())
 		s.Run(locks1[k].Name(), func() {
 			var shared int
 			rounds := 6


### PR DESCRIPTION
Currently there are multiple implementations and they are tested in a loop. If any of them fail, it is not easy to tell where it comes from. With `Name` on the interface `DistLocker` and use it for subtests will help.

It will look like this if this PR is merged.
```
=== RUN   TestBucketTestSuite/TestDistLockers
=== RUN   TestBucketTestSuite/TestDistLockers/LockEtcd
=== RUN   TestBucketTestSuite/TestDistLockers/LockConsul
=== RUN   TestBucketTestSuite/TestDistLockers/LockZookeeper
=== RUN   TestBucketTestSuite/TestDistLockers/LockRedis
```

We should probably to the same to all interfaces.