### PR TITLE
Use redis universal client in token bucket

### DIFF
--- a/concurrent_buffer.go
+++ b/concurrent_buffer.go
@@ -106,7 +106,7 @@ func (c *ConcurrentBufferInMemory) Remove(_ context.Context, key string) error {
 // ConcurrentBufferRedis implements ConcurrentBufferBackend in Redis.
 type ConcurrentBufferRedis struct {
 	clock Clock
-	cli   *redis.Client
+	cli   redis.UniversalClient
 	key   string
 	ttl   time.Duration
 }
@@ -114,7 +114,7 @@ type ConcurrentBufferRedis struct {
 // NewConcurrentBufferRedis creates a new instance of ConcurrentBufferRedis.
 // When the TTL of a key exceeds the key is removed from the buffer. This is needed in case if the process that added
 // that key to the buffer did not call Done() for some reason.
-func NewConcurrentBufferRedis(cli *redis.Client, key string, ttl time.Duration, clock Clock) *ConcurrentBufferRedis {
+func NewConcurrentBufferRedis(cli redis.UniversalClient, key string, ttl time.Duration, clock Clock) *ConcurrentBufferRedis {
 	return &ConcurrentBufferRedis{clock: clock, cli: cli, key: key, ttl: ttl}
 }
 

--- a/fixedwindow.go
+++ b/fixedwindow.go
@@ -97,13 +97,13 @@ func (f *FixedWindowInMemory) Increment(ctx context.Context, window time.Time, _
 
 // FixedWindowRedis implements FixedWindow in Redis.
 type FixedWindowRedis struct {
-	cli    *redis.Client
+	cli    redis.UniversalClient
 	prefix string
 }
 
 // NewFixedWindowRedis returns a new instance of FixedWindowRedis.
 // Prefix is the key prefix used to store all the keys used in this implementation in Redis.
-func NewFixedWindowRedis(cli *redis.Client, prefix string) *FixedWindowRedis {
+func NewFixedWindowRedis(cli redis.UniversalClient, prefix string) *FixedWindowRedis {
 	return &FixedWindowRedis{cli: cli, prefix: prefix}
 }
 

--- a/leakybucket.go
+++ b/leakybucket.go
@@ -272,7 +272,7 @@ const (
 
 // LeakyBucketRedis is a Redis implementation of a LeakyBucketStateBackend.
 type LeakyBucketRedis struct {
-	cli         *redis.Client
+	cli         redis.UniversalClient
 	prefix      string
 	ttl         time.Duration
 	raceCheck   bool
@@ -285,7 +285,7 @@ type LeakyBucketRedis struct {
 //
 // If raceCheck is true and the keys in Redis are modified in between State() and SetState() calls then
 // ErrRaceCondition is returned.
-func NewLeakyBucketRedis(cli *redis.Client, prefix string, ttl time.Duration, raceCheck bool) *LeakyBucketRedis {
+func NewLeakyBucketRedis(cli redis.UniversalClient, prefix string, ttl time.Duration, raceCheck bool) *LeakyBucketRedis {
 	return &LeakyBucketRedis{cli: cli, prefix: prefix, ttl: ttl, raceCheck: raceCheck}
 }
 

--- a/limiters_test.go
+++ b/limiters_test.go
@@ -64,7 +64,7 @@ func (c *fakeClock) reset() {
 type LimitersTestSuite struct {
 	suite.Suite
 	etcdClient         *clientv3.Client
-	redisClient        *redis.Client
+	redisClient        redis.UniversalClient
 	consulClient       *api.Client
 	zkConn             *zk.Conn
 	logger             *l.StdLogger

--- a/slidingwindow.go
+++ b/slidingwindow.go
@@ -105,12 +105,12 @@ func (s *SlidingWindowInMemory) Increment(ctx context.Context, prev, curr time.T
 
 // SlidingWindowRedis implements SlidingWindow in Redis.
 type SlidingWindowRedis struct {
-	cli    *redis.Client
+	cli    redis.UniversalClient
 	prefix string
 }
 
 // NewSlidingWindowRedis creates a new instance of SlidingWindowRedis.
-func NewSlidingWindowRedis(cli *redis.Client, prefix string) *SlidingWindowRedis {
+func NewSlidingWindowRedis(cli redis.UniversalClient, prefix string) *SlidingWindowRedis {
 	return &SlidingWindowRedis{cli: cli, prefix: prefix}
 }
 

--- a/tokenbucket.go
+++ b/tokenbucket.go
@@ -344,7 +344,7 @@ func redisKey(prefix, key string) string {
 // Although depending on a persistence and a cluster configuration some data might be lost in case of a failure
 // resulting in an under-limiting the accesses to the service.
 type TokenBucketRedis struct {
-	cli         *redis.Client
+	cli         redis.UniversalClient
 	prefix      string
 	ttl         time.Duration
 	raceCheck   bool
@@ -358,7 +358,7 @@ type TokenBucketRedis struct {
 // If raceCheck is true and the keys in Redis are modified in between State() and SetState() calls then
 // ErrRaceCondition is returned.
 // This adds an extra overhead since a Lua script has to be executed on the Redis side which locks the entire database.
-func NewTokenBucketRedis(cli *redis.Client, prefix string, ttl time.Duration, raceCheck bool) *TokenBucketRedis {
+func NewTokenBucketRedis(cli redis.UniversalClient, prefix string, ttl time.Duration, raceCheck bool) *TokenBucketRedis {
 	return &TokenBucketRedis{cli: cli, prefix: prefix, ttl: ttl, raceCheck: raceCheck}
 }
 


### PR DESCRIPTION
Updated the client to a UniversalClient, which works for redis pools as well as single redis servers.