### PR TITLE
add TestConcurrentBufferDuplicateKeys

### DIFF
--- a/concurrent_buffer_test.go
+++ b/concurrent_buffer_test.go
@@ -89,3 +89,15 @@ func (s *LimitersTestSuite) TestConcurrentBufferExpiredKeys() {
 		s.NoError(buffer.Limit(context.TODO(), "key3"))
 	}
 }
+
+func (s *LimitersTestSuite) TestConcurrentBufferDuplicateKeys() {
+	clock := newFakeClock()
+	capacity := int64(2)
+	ttl := time.Second
+	for _, buffer := range s.concurrentBuffers(capacity, ttl, clock) {
+		s.Require().NoError(buffer.Limit(context.TODO(), "key1"))
+		s.Require().NoError(buffer.Limit(context.TODO(), "key2"))
+		// No error is expected as it should just update the timestamp of the existing key.
+		s.NoError(buffer.Limit(context.TODO(), "key1"))
+	}
+}


### PR DESCRIPTION
Adding a new test TestConcurrentBufferDuplicateKeys and fix ConcurrenfBufferMemcached to make sure it follows the other implementations to actually act as a set and handle duplicates correctly.