### PR TITLE
Add LockMySQL

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,12 @@ jobs:
           ALLOW_EMPTY_PASSWORD: yes
         ports:
           - 5432:5432
+      mysql:
+        image: bitnami/mysql
+        env:
+          ALLOW_EMPTY_PASSWORD: yes
+        ports:
+          - "3306:3306"
 
     steps:
       - uses: actions/checkout@v4
@@ -61,8 +67,9 @@ jobs:
           CONSUL_ADDR: 'localhost:8500'
           ZOOKEEPER_ENDPOINTS: 'localhost:2181'
           AWS_ADDR: 'localhost:8000'
-          MEMCACHED_ADDR: '127.0.0.1:11211'
+          MEMCACHED_ADDR: 'localhost:11211'
           POSTGRES_URL: postgres://postgres@localhost:5432/?sslmode=disable
+          MYSQL_URL: root@tcp(localhost:3306)/
         run: go test -race -v -coverprofile=coverage.txt -covermode=atomic ./...
       - uses: codecov/codecov-action@v4.1.0
         with:

--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,4 @@ all: test
 
 test:
 	docker-compose up -d
-	ETCD_ENDPOINTS="127.0.0.1:2379" REDIS_ADDR="127.0.0.1:6379" ZOOKEEPER_ENDPOINTS="127.0.0.1" CONSUL_ADDR="127.0.0.1:8500" AWS_ADDR="127.0.0.1:8000" MEMCACHED_ADDR="127.0.0.1:11211" POSTGRES_URL="postgres://postgres@localhost:5432/?sslmode=disable" go test -race -v -failfast -bench=.
+	ETCD_ENDPOINTS="localhost:2379" REDIS_ADDR="localhost:6379" ZOOKEEPER_ENDPOINTS="localhost" CONSUL_ADDR="localhost:8500" AWS_ADDR="localhost:8000" MEMCACHED_ADDR="localhost:11211" POSTGRES_URL="postgres://postgres@localhost:5432/?sslmode=disable" MYSQL_URL="root@tcp(localhost:3306)/" go test -race -v -failfast -bench=.

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Supported backends:
 - [Redis](https://redis.io/)
 - [Memcached](https://memcached.org/)
 - [PostgreSQL](https://www.postgresql.org/)
+- [MySQL](https://www.mysql.com/)
 
 ## Memcached
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,3 +44,10 @@ services:
       ALLOW_EMPTY_PASSWORD: yes
     ports:
       - "5432:5432"
+
+  mysql:
+    image: bitnami/mysql
+    environment:
+      ALLOW_EMPTY_PASSWORD: yes
+    ports:
+      - "3306:3306"

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.17.6
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.19.1
 	github.com/cenkalti/backoff/v3 v3.2.2
+	github.com/go-sql-driver/mysql v1.7.1
 	github.com/lib/pq v1.10.9
 )
 

--- a/go.sum
+++ b/go.sum
@@ -768,6 +768,8 @@ github.com/go-redis/redis/v8 v8.11.4 h1:kHoYkfZP6+pe04aFTnhDH6GDROa5yJdHJVNxV3F4
 github.com/go-redis/redis/v8 v8.11.4/go.mod h1:2Z2wHZXdQpCDXEGzqMockDpNyYvi2l4Pxt6RJr792+w=
 github.com/go-redsync/redsync/v4 v4.8.1 h1:rq2RvdTI0obznMdxKUWGdmmulo7lS9yCzb8fgDKOlbM=
 github.com/go-redsync/redsync/v4 v4.8.1/go.mod h1:LmUAsQuQxhzZAoGY7JS6+dNhNmZyonMZiiEDY9plotM=
+github.com/go-sql-driver/mysql v1.7.1 h1:lUIinVbN1DY0xBg0eMOzmmtGoHwWBbvnWubQUrtU8EI=
+github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/goccy/go-json v0.9.11/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=

--- a/limiters_test.go
+++ b/limiters_test.go
@@ -73,7 +73,7 @@ type LimitersTestSuite struct {
 	dynamodbClient     *dynamodb.Client
 	dynamoDBTableProps l.DynamoDBTableProperties
 	memcacheClient     *memcache.Client
-	pgDb               []*sql.DB
+	db                 []*sql.DB
 }
 
 func (s *LimitersTestSuite) SetupSuite() {
@@ -122,16 +122,25 @@ func (s *LimitersTestSuite) SetupSuite() {
 	s.memcacheClient = memcache.New(strings.Split(os.Getenv("MEMCACHED_ADDR"), ",")...)
 	s.Require().NoError(s.memcacheClient.Ping())
 
-	s.pgDb = []*sql.DB{}
+	s.db = make([]*sql.DB, 0)
 }
 
 func (s *LimitersTestSuite) openPgDb() *sql.DB {
-	var pgDb *sql.DB
-	pgDb, err := sql.Open("postgres", os.Getenv("POSTGRES_URL"))
+	var db *sql.DB
+	db, err := sql.Open("postgres", os.Getenv("POSTGRES_URL"))
 	s.Require().NoError(err)
-	s.Require().NoError(pgDb.Ping())
-	s.pgDb = append(s.pgDb, pgDb)
-	return pgDb
+	s.Require().NoError(db.Ping())
+	s.db = append(s.db, db)
+	return db
+}
+
+func (s *LimitersTestSuite) openMyDb() *sql.DB {
+	var db *sql.DB
+	db, err := sql.Open("mysql", os.Getenv("MYSQL_URL"))
+	s.Require().NoError(err)
+	s.Require().NoError(db.Ping())
+	s.db = append(s.db, db)
+	return db
 }
 
 func (s *LimitersTestSuite) TearDownSuite() {
@@ -139,8 +148,8 @@ func (s *LimitersTestSuite) TearDownSuite() {
 	s.Assert().NoError(s.redisClient.Close())
 	s.Assert().NoError(DeleteTestDynamoDBTable(context.Background(), s.dynamodbClient))
 	s.Assert().NoError(s.memcacheClient.Close())
-	for _, pgDb := range s.pgDb {
-		s.Assert().NoError(pgDb.Close())
+	for _, db := range s.db {
+		s.Assert().NoError(db.Close())
 	}
 }
 
@@ -173,6 +182,7 @@ func (s *LimitersTestSuite) distLockers(generateKeys bool) map[string]l.DistLock
 	redisKey := randomKey
 	memcacheKey := randomKey
 	pgKey := randomKey
+	myKey := randomKey
 	if !generateKeys {
 		consulKey = "dist_locker"
 		etcdKey = "dist_locker"
@@ -180,6 +190,7 @@ func (s *LimitersTestSuite) distLockers(generateKeys bool) map[string]l.DistLock
 		redisKey = "dist_locker"
 		memcacheKey = "dist_locker"
 		pgKey = "dist_locker"
+		myKey = "dist_locker"
 	}
 	consulLock, err := s.consulClient.LockKey(consulKey)
 	s.Require().NoError(err)
@@ -190,6 +201,7 @@ func (s *LimitersTestSuite) distLockers(generateKeys bool) map[string]l.DistLock
 		"LockRedis":      l.NewLockRedis(goredis.NewPool(s.redisClient), redisKey),
 		"LockMemcached":  l.NewLockMemcached(s.memcacheClient, memcacheKey),
 		"LockPostgreSQL": l.NewLockPostgreSQL(s.openPgDb(), hash(pgKey)),
+		"LockMySQL":      l.NewLockMySQL(s.openMyDb(), myKey),
 	}
 }
 


### PR DESCRIPTION
Add `LockMySQL` using [MySQL's user-level lock](https://dev.mysql.com/doc/refman/8.3/en/locking-functions.html). Also, using one database connection to create multiple lockers is probably not how it is used in normal cases, so revert LockPostgreSQL to use session-level as well to maintain the same syntax like LockMySQL

LockRedis is still the most performant lock. LockMemcached, LockPostgreSQL and LockMySQL are about the same.
```
goos: darwin
goarch: amd64
pkg: github.com/mennanov/limiters
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkDistLockers
2024/03/18 23:31:21 Connected to 127.0.0.1:2181
2024/03/18 23:31:21 authenticated: id=72065004698337301, timeout=4000
2024/03/18 23:31:21 re-submitting `0` credentials after reconnect
BenchmarkDistLockers/LockMySQL
BenchmarkDistLockers/LockMySQL-12                   1032           1090960 ns/op
BenchmarkDistLockers/LockEtcd
BenchmarkDistLockers/LockEtcd-12                     274           4639649 ns/op
BenchmarkDistLockers/LockConsul
BenchmarkDistLockers/LockConsul-12                   201           5889630 ns/op
BenchmarkDistLockers/LockZookeeper
BenchmarkDistLockers/LockZookeeper-12                440           2722693 ns/op
BenchmarkDistLockers/LockRedis
BenchmarkDistLockers/LockRedis-12                   2056            612462 ns/op
BenchmarkDistLockers/LockMemcached
BenchmarkDistLockers/LockMemcached-12               1104           1089090 ns/op
BenchmarkDistLockers/LockPostgreSQL
BenchmarkDistLockers/LockPostgreSQL-12              1083           1128017 ns/op
```
