### PR TITLE
Fix redisKey and ZCount

### DIFF
--- a/concurrent_buffer.go
+++ b/concurrent_buffer.go
@@ -134,7 +134,7 @@ func (c *ConcurrentBufferRedis) Add(ctx context.Context, key string) (int64, err
 				Score:  float64(now.UnixNano()),
 				Member: key,
 			})
-			countCmd = pipeliner.ZCount(ctx, c.key, "-inf", "+inf")
+			countCmd = pipeliner.ZCard(ctx, c.key)
 			return nil
 		})
 	}()

--- a/tokenbucket.go
+++ b/tokenbucket.go
@@ -331,8 +331,14 @@ const (
 	redisKeyTBVersion   = "version"
 )
 
+// If we do use cluster client and if the cluster is large enough, it is possible that when accessing multiple keys
+// in leaky bucket or token bucket, these keys might go different slots and it will fail with error message
+// `CROSSSLOT Keys in request don't hash to the same slot`. Adding hash tags in redisKey will force them into the
+// same slot for keys with the same prefix.
+//
+// https://redis.io/docs/latest/operate/oss_and_stack/reference/cluster-spec/#hash-tags
 func redisKey(prefix, key string) string {
-	return fmt.Sprintf("%s/%s", prefix, key)
+	return fmt.Sprintf("{%s}%s", prefix, key)
 }
 
 // TokenBucketRedis is a Redis implementation of a TokenBucketStateBackend.


### PR DESCRIPTION
This PR fixes two issues

- Add hash tags in redisKey: earlier in https://github.com/mennanov/limiters/pull/34 we replaced `redis.Client` with `redis.UniversalClient`. If we do use cluster client and if the cluster is large enough, it is possible that when accessing multiple keys in [leaky bucket](https://github.com/mennanov/limiters/blob/master/leakybucket.go#L305) or [token bucket](https://github.com/mennanov/limiters/blob/master/tokenbucket.go#L385), these keys might go different slots and it will fail with error message `CROSSSLOT Keys in request don't hash to the same slot`. Adding [hash tags](https://redis.io/docs/latest/operate/oss_and_stack/reference/cluster-spec/#hash-tags) in `redisKey` will force them into the same slot for keys with the same prefix.
- Replace ZCount with ZCard: [ZCount](https://redis.io/docs/latest/commands/zcount/) is O(log(N)) while [ZCard](https://redis.io/docs/latest/commands/zcard/) is O(1). It probably doesn't matter in the most cases but it helps a little bit if the sorted set size is huge.