### PR TITLE
add redis cluster client tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,12 @@ jobs:
           ALLOW_EMPTY_PASSWORD: yes
         ports:
           - 6379:6379
+      redis-cluster:
+        image: grokzen/redis-cluster:7.0.10
+        env:
+          IP: 0.0.0.0
+        ports:
+          - 7000-7005:7000-7005
       memcached:
         image: bitnami/memcached
         ports:
@@ -58,6 +64,7 @@ jobs:
         env:
           ETCD_ENDPOINTS: 'localhost:2379'
           REDIS_ADDR: 'localhost:6379'
+          REDIS_NODES: 'localhost:7000,localhost:7001,localhost:7002,localhost:7003,localhost:7004,localhost:7005'
           CONSUL_ADDR: 'localhost:8500'
           ZOOKEEPER_ENDPOINTS: 'localhost:2181'
           AWS_ADDR: 'localhost:8000'

--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,4 @@ all: test
 
 test:
 	docker-compose up -d
-	ETCD_ENDPOINTS="127.0.0.1:2379" REDIS_ADDR="127.0.0.1:6379" ZOOKEEPER_ENDPOINTS="127.0.0.1" CONSUL_ADDR="127.0.0.1:8500" AWS_ADDR="127.0.0.1:8000" MEMCACHED_ADDR="127.0.0.1:11211" POSTGRES_URL="postgres://postgres@localhost:5432/?sslmode=disable" go test -race -v -failfast -bench=.
+	ETCD_ENDPOINTS="127.0.0.1:2379" REDIS_ADDR="127.0.0.1:6379" REDIS_NODES="127.0.0.1:7000,127.0.0.1:7001,127.0.0.1:7002,127.0.0.1:7003,127.0.0.1:7004,127.0.0.1:7005" ZOOKEEPER_ENDPOINTS="127.0.0.1" CONSUL_ADDR="127.0.0.1:8500" AWS_ADDR="127.0.0.1:8000" MEMCACHED_ADDR="127.0.0.1:11211" POSTGRES_URL="postgres://postgres@localhost:5432/?sslmode=disable" go test -race -v -failfast -bench=.

--- a/concurrent_buffer_test.go
+++ b/concurrent_buffer_test.go
@@ -24,9 +24,10 @@ func (s *LimitersTestSuite) concurrentBuffers(capacity int64, ttl time.Duration,
 
 func (s *LimitersTestSuite) concurrentBufferBackends(ttl time.Duration, clock l.Clock) map[string]l.ConcurrentBufferBackend {
 	return map[string]l.ConcurrentBufferBackend{
-		"ConcurrentBufferInMemory":  l.NewConcurrentBufferInMemory(l.NewRegistry(), ttl, clock),
-		"ConcurrentBufferRedis":     l.NewConcurrentBufferRedis(s.redisClient, uuid.New().String(), ttl, clock),
-		"ConcurrentBufferMemcached": l.NewConcurrentBufferMemcached(s.memcacheClient, uuid.New().String(), ttl, clock),
+		"ConcurrentBufferInMemory":     l.NewConcurrentBufferInMemory(l.NewRegistry(), ttl, clock),
+		"ConcurrentBufferRedis":        l.NewConcurrentBufferRedis(s.redisClient, uuid.New().String(), ttl, clock),
+		"ConcurrentBufferRedisCluster": l.NewConcurrentBufferRedis(s.redisClusterClient, uuid.New().String(), ttl, clock),
+		"ConcurrentBufferMemcached":    l.NewConcurrentBufferMemcached(s.memcacheClient, uuid.New().String(), ttl, clock),
 	}
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,13 @@ services:
     ports:
       - "6379:6379"
 
+  redis-cluster:
+    image: grokzen/redis-cluster:7.0.10
+    environment:
+      IP: "0.0.0.0"
+    ports:
+      - "7000-7005:7000-7005"
+
   memcached:
     image: bitnami/memcached
     ports:

--- a/fixedwindow_test.go
+++ b/fixedwindow_test.go
@@ -20,10 +20,11 @@ func (s *LimitersTestSuite) fixedWindows(capacity int64, rate time.Duration, clo
 
 func (s *LimitersTestSuite) fixedWindowIncrementers() map[string]l.FixedWindowIncrementer {
 	return map[string]l.FixedWindowIncrementer{
-		"FixedWindowInMemory":  l.NewFixedWindowInMemory(),
-		"FixedWindowRedis":     l.NewFixedWindowRedis(s.redisClient, uuid.New().String()),
-		"FixedWindowMemcached": l.NewFixedWindowMemcached(s.memcacheClient, uuid.New().String()),
-		"FixedWindowDynamoDB":  l.NewFixedWindowDynamoDB(s.dynamodbClient, uuid.New().String(), s.dynamoDBTableProps),
+		"FixedWindowInMemory":     l.NewFixedWindowInMemory(),
+		"FixedWindowRedis":        l.NewFixedWindowRedis(s.redisClient, uuid.New().String()),
+		"FixedWindowRedisCluster": l.NewFixedWindowRedis(s.redisClusterClient, uuid.New().String()),
+		"FixedWindowMemcached":    l.NewFixedWindowMemcached(s.memcacheClient, uuid.New().String()),
+		"FixedWindowDynamoDB":     l.NewFixedWindowDynamoDB(s.dynamodbClient, uuid.New().String(), s.dynamoDBTableProps),
 	}
 }
 

--- a/leakybucket_test.go
+++ b/leakybucket_test.go
@@ -23,15 +23,17 @@ func (s *LimitersTestSuite) leakyBuckets(capacity int64, rate time.Duration, clo
 
 func (s *LimitersTestSuite) leakyBucketBackends() map[string]l.LeakyBucketStateBackend {
 	return map[string]l.LeakyBucketStateBackend{
-		"LeakyBucketInMemory":               l.NewLeakyBucketInMemory(),
-		"LeakyBucketEtcdNoRaceCheck":        l.NewLeakyBucketEtcd(s.etcdClient, uuid.New().String(), time.Second, false),
-		"LeakyBucketEtcdWithRaceCheck":      l.NewLeakyBucketEtcd(s.etcdClient, uuid.New().String(), time.Second, true),
-		"LeakyBucketRedisNoRaceCheck":       l.NewLeakyBucketRedis(s.redisClient, uuid.New().String(), time.Second, false),
-		"LeakyBucketRedisWithRaceCheck":     l.NewLeakyBucketRedis(s.redisClient, uuid.New().String(), time.Second, true),
-		"LeakyBucketMemcachedNoRaceCheck":   l.NewLeakyBucketMemcached(s.memcacheClient, uuid.New().String(), time.Second, false),
-		"LeakyBucketMemcachedWithRaceCheck": l.NewLeakyBucketMemcached(s.memcacheClient, uuid.New().String(), time.Second, true),
-		"LeakyBucketDynamoDBNoRaceCheck":    l.NewLeakyBucketDynamoDB(s.dynamodbClient, uuid.New().String(), s.dynamoDBTableProps, time.Second, false),
-		"LeakyBucketDynamoDBWithRaceCheck":  l.NewLeakyBucketDynamoDB(s.dynamodbClient, uuid.New().String(), s.dynamoDBTableProps, time.Second, true),
+		"LeakyBucketInMemory":                  l.NewLeakyBucketInMemory(),
+		"LeakyBucketEtcdNoRaceCheck":           l.NewLeakyBucketEtcd(s.etcdClient, uuid.New().String(), time.Second, false),
+		"LeakyBucketEtcdWithRaceCheck":         l.NewLeakyBucketEtcd(s.etcdClient, uuid.New().String(), time.Second, true),
+		"LeakyBucketRedisNoRaceCheck":          l.NewLeakyBucketRedis(s.redisClient, uuid.New().String(), time.Second, false),
+		"LeakyBucketRedisWithRaceCheck":        l.NewLeakyBucketRedis(s.redisClient, uuid.New().String(), time.Second, true),
+		"LeakyBucketRedisClusterNoRaceCheck":   l.NewLeakyBucketRedis(s.redisClusterClient, uuid.New().String(), time.Second, false),
+		"LeakyBucketRedisClusterWithRaceCheck": l.NewLeakyBucketRedis(s.redisClusterClient, uuid.New().String(), time.Second, true),
+		"LeakyBucketMemcachedNoRaceCheck":      l.NewLeakyBucketMemcached(s.memcacheClient, uuid.New().String(), time.Second, false),
+		"LeakyBucketMemcachedWithRaceCheck":    l.NewLeakyBucketMemcached(s.memcacheClient, uuid.New().String(), time.Second, true),
+		"LeakyBucketDynamoDBNoRaceCheck":       l.NewLeakyBucketDynamoDB(s.dynamodbClient, uuid.New().String(), s.dynamoDBTableProps, time.Second, false),
+		"LeakyBucketDynamoDBWithRaceCheck":     l.NewLeakyBucketDynamoDB(s.dynamodbClient, uuid.New().String(), s.dynamoDBTableProps, time.Second, true),
 	}
 }
 

--- a/slidingwindow_test.go
+++ b/slidingwindow_test.go
@@ -20,10 +20,11 @@ func (s *LimitersTestSuite) slidingWindows(capacity int64, rate time.Duration, c
 
 func (s *LimitersTestSuite) slidingWindowIncrementers() map[string]l.SlidingWindowIncrementer {
 	return map[string]l.SlidingWindowIncrementer{
-		"SlidingWindowInMemory":  l.NewSlidingWindowInMemory(),
-		"SlidingWindowRedis":     l.NewSlidingWindowRedis(s.redisClient, uuid.New().String()),
-		"SlidingWindowMemcached": l.NewSlidingWindowMemcached(s.memcacheClient, uuid.New().String()),
-		"SlidingWindowDynamoDB":  l.NewSlidingWindowDynamoDB(s.dynamodbClient, uuid.New().String(), s.dynamoDBTableProps),
+		"SlidingWindowInMemory":     l.NewSlidingWindowInMemory(),
+		"SlidingWindowRedis":        l.NewSlidingWindowRedis(s.redisClient, uuid.New().String()),
+		"SlidingWindowRedisCluster": l.NewSlidingWindowRedis(s.redisClusterClient, uuid.New().String()),
+		"SlidingWindowMemcached":    l.NewSlidingWindowMemcached(s.memcacheClient, uuid.New().String()),
+		"SlidingWindowDynamoDB":     l.NewSlidingWindowDynamoDB(s.dynamodbClient, uuid.New().String(), s.dynamoDBTableProps),
 	}
 }
 

--- a/tokenbucket_test.go
+++ b/tokenbucket_test.go
@@ -80,15 +80,17 @@ func (s *LimitersTestSuite) tokenBuckets(capacity int64, refillRate time.Duratio
 
 func (s *LimitersTestSuite) tokenBucketBackends() map[string]l.TokenBucketStateBackend {
 	return map[string]l.TokenBucketStateBackend{
-		"TokenBucketInMemory":               l.NewTokenBucketInMemory(),
-		"TokenBucketEtcdNoRaceCheck":        l.NewTokenBucketEtcd(s.etcdClient, uuid.New().String(), time.Second, false),
-		"TokenBucketEtcdWithRaceCheck":      l.NewTokenBucketEtcd(s.etcdClient, uuid.New().String(), time.Second, true),
-		"TokenBucketRedisNoRaceCheck":       l.NewTokenBucketRedis(s.redisClient, uuid.New().String(), time.Second, false),
-		"TokenBucketRedisWithRaceCheck":     l.NewTokenBucketRedis(s.redisClient, uuid.New().String(), time.Second, true),
-		"TokenBucketMemcachedNoRaceCheck":   l.NewTokenBucketMemcached(s.memcacheClient, uuid.New().String(), time.Second, false),
-		"TokenBucketMemcachedWithRaceCheck": l.NewTokenBucketMemcached(s.memcacheClient, uuid.New().String(), time.Second, true),
-		"TokenBucketDynamoDBNoRaceCheck":    l.NewTokenBucketDynamoDB(s.dynamodbClient, uuid.New().String(), s.dynamoDBTableProps, time.Second, false),
-		"TokenBucketDynamoDBWithRaceCheck":  l.NewTokenBucketDynamoDB(s.dynamodbClient, uuid.New().String(), s.dynamoDBTableProps, time.Second, true),
+		"TokenBucketInMemory":                  l.NewTokenBucketInMemory(),
+		"TokenBucketEtcdNoRaceCheck":           l.NewTokenBucketEtcd(s.etcdClient, uuid.New().String(), time.Second, false),
+		"TokenBucketEtcdWithRaceCheck":         l.NewTokenBucketEtcd(s.etcdClient, uuid.New().String(), time.Second, true),
+		"TokenBucketRedisNoRaceCheck":          l.NewTokenBucketRedis(s.redisClient, uuid.New().String(), time.Second, false),
+		"TokenBucketRedisWithRaceCheck":        l.NewTokenBucketRedis(s.redisClient, uuid.New().String(), time.Second, true),
+		"TokenBucketRedisClusterNoRaceCheck":   l.NewTokenBucketRedis(s.redisClusterClient, uuid.New().String(), time.Second, false),
+		"TokenBucketRedisClusterWithRaceCheck": l.NewTokenBucketRedis(s.redisClusterClient, uuid.New().String(), time.Second, true),
+		"TokenBucketMemcachedNoRaceCheck":      l.NewTokenBucketMemcached(s.memcacheClient, uuid.New().String(), time.Second, false),
+		"TokenBucketMemcachedWithRaceCheck":    l.NewTokenBucketMemcached(s.memcacheClient, uuid.New().String(), time.Second, true),
+		"TokenBucketDynamoDBNoRaceCheck":       l.NewTokenBucketDynamoDB(s.dynamodbClient, uuid.New().String(), s.dynamoDBTableProps, time.Second, false),
+		"TokenBucketDynamoDBWithRaceCheck":     l.NewTokenBucketDynamoDB(s.dynamodbClient, uuid.New().String(), s.dynamoDBTableProps, time.Second, true),
 	}
 }
 


### PR DESCRIPTION
I should have done this in https://github.com/mennanov/limiters/pull/48, but I think it is not too late to do it now.

The existing test environment only has single node Redis and there is no Redis cluster.
Given that the Redis and Redis cluster may behave differently, I think we should test them separately.

- keep Redis at port 6379 while adding Redis cluster at port 7000-7005
- whenever we test Redis, we test Redis cluster as well

Also run it in two builds:
- remove hash tags in redisKey to [reproduce](https://github.com/mennanov/limiters/actions/runs/9203665031/job/25315630381?pr=50#step:6:189) the error `CROSSSLOT Keys in request don't hash to the same slot`
- add hash tags back in redisKey to show that it works