### PR TITLE
add benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
-all: test
+all: test benchmark
 
-test:
+docker-compose-up:
 	docker-compose up -d
-	ETCD_ENDPOINTS="127.0.0.1:2379" REDIS_ADDR="127.0.0.1:6379" REDIS_NODES="127.0.0.1:7000,127.0.0.1:7001,127.0.0.1:7002,127.0.0.1:7003,127.0.0.1:7004,127.0.0.1:7005" ZOOKEEPER_ENDPOINTS="127.0.0.1" CONSUL_ADDR="127.0.0.1:8500" AWS_ADDR="127.0.0.1:8000" MEMCACHED_ADDR="127.0.0.1:11211" POSTGRES_URL="postgres://postgres@localhost:5432/?sslmode=disable" go test -race -v -failfast -bench=.
+
+test: docker-compose-up
+	ETCD_ENDPOINTS="127.0.0.1:2379" REDIS_ADDR="127.0.0.1:6379" REDIS_NODES="127.0.0.1:7000,127.0.0.1:7001,127.0.0.1:7002,127.0.0.1:7003,127.0.0.1:7004,127.0.0.1:7005" ZOOKEEPER_ENDPOINTS="127.0.0.1" CONSUL_ADDR="127.0.0.1:8500" AWS_ADDR="127.0.0.1:8000" MEMCACHED_ADDR="127.0.0.1:11211" POSTGRES_URL="postgres://postgres@localhost:5432/?sslmode=disable" go test -race -v -failfast
+
+benchmark: docker-compose-up
+	ETCD_ENDPOINTS="127.0.0.1:2379" REDIS_ADDR="127.0.0.1:6379" REDIS_NODES="127.0.0.1:7000,127.0.0.1:7001,127.0.0.1:7002,127.0.0.1:7003,127.0.0.1:7004,127.0.0.1:7005" ZOOKEEPER_ENDPOINTS="127.0.0.1" CONSUL_ADDR="127.0.0.1:8500" AWS_ADDR="127.0.0.1:8000" MEMCACHED_ADDR="127.0.0.1:11211" POSTGRES_URL="postgres://postgres@localhost:5432/?sslmode=disable" go test -race -run=nonexistent -bench=.

--- a/README.md
+++ b/README.md
@@ -143,5 +143,13 @@ If memcached exists already and it is okay to handle burst traffic caused by une
 
 Run tests locally:
 ```bash
+make test
+```
+Run benchmarks locally:
+```bash
+make benchmark
+```
+Run both locally:
+```bash
 make
 ```

--- a/concurrent_buffer_test.go
+++ b/concurrent_buffer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/google/uuid"
@@ -109,4 +110,22 @@ func (s *LimitersTestSuite) TestConcurrentBufferDuplicateKeys() {
 			s.NoError(buffer.Limit(context.TODO(), "key1"))
 		})
 	}
+}
+
+func BenchmarkConcurrentBuffers(b *testing.B) {
+	s := new(LimitersTestSuite)
+	s.SetT(&testing.T{})
+	s.SetupSuite()
+	capacity := int64(1)
+	ttl := time.Second
+	clock := newFakeClock()
+	buffers := s.concurrentBuffers(capacity, ttl, clock)
+	for name, buffer := range buffers {
+		b.Run(name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				s.Require().NoError(buffer.Limit(context.TODO(), "key1"))
+			}
+		})
+	}
+	s.TearDownSuite()
 }

--- a/fixedwindow_test.go
+++ b/fixedwindow_test.go
@@ -2,6 +2,7 @@ package limiters_test
 
 import (
 	"context"
+	"testing"
 	"time"
 
 	"github.com/google/uuid"
@@ -101,4 +102,23 @@ func (s *LimitersTestSuite) TestFixedWindowOverflow() {
 			s.Equal(time.Duration(0), w)
 		})
 	}
+}
+
+func BenchmarkFixedWindows(b *testing.B) {
+	s := new(LimitersTestSuite)
+	s.SetT(&testing.T{})
+	s.SetupSuite()
+	capacity := int64(1)
+	rate := time.Second
+	clock := newFakeClock()
+	windows := s.fixedWindows(capacity, rate, clock)
+	for name, window := range windows {
+		b.Run(name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, err := window.Limit(context.TODO())
+				s.Require().NoError(err)
+			}
+		})
+	}
+	s.TearDownSuite()
 }

--- a/leakybucket_test.go
+++ b/leakybucket_test.go
@@ -3,6 +3,7 @@ package limiters_test
 import (
 	"context"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/google/uuid"
@@ -139,4 +140,23 @@ func (s *LimitersTestSuite) TestLeakyBucketOverflow() {
 			s.Equal(rate*2, wait)
 		})
 	}
+}
+
+func BenchmarkLeakyBuckets(b *testing.B) {
+	s := new(LimitersTestSuite)
+	s.SetT(&testing.T{})
+	s.SetupSuite()
+	capacity := int64(1)
+	rate := time.Second
+	clock := newFakeClock()
+	buckets := s.leakyBuckets(capacity, rate, clock)
+	for name, bucket := range buckets {
+		b.Run(name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, err := bucket.Limit(context.TODO())
+				s.Require().NoError(err)
+			}
+		})
+	}
+	s.TearDownSuite()
 }

--- a/slidingwindow_test.go
+++ b/slidingwindow_test.go
@@ -2,6 +2,7 @@ package limiters_test
 
 import (
 	"context"
+	"testing"
 	"time"
 
 	"github.com/google/uuid"
@@ -305,4 +306,24 @@ func (s *LimitersTestSuite) TestSlidingWindowOverflowAndWait() {
 			})
 		}
 	}
+}
+
+func BenchmarkSlidingWindows(b *testing.B) {
+	s := new(LimitersTestSuite)
+	s.SetT(&testing.T{})
+	s.SetupSuite()
+	capacity := int64(1)
+	rate := time.Second
+	clock := newFakeClock()
+	epsilon := 1e-9
+	windows := s.slidingWindows(capacity, rate, clock, epsilon)
+	for name, window := range windows {
+		b.Run(name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, err := window.Limit(context.TODO())
+				s.Require().NoError(err)
+			}
+		})
+	}
+	s.TearDownSuite()
 }

--- a/tokenbucket_test.go
+++ b/tokenbucket_test.go
@@ -3,6 +3,7 @@ package limiters_test
 import (
 	"context"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/google/uuid"
@@ -202,4 +203,23 @@ func (s *LimitersTestSuite) TestTokenBucketRefill() {
 			}
 		})
 	}
+}
+
+func BenchmarkTokenBuckets(b *testing.B) {
+	s := new(LimitersTestSuite)
+	s.SetT(&testing.T{})
+	s.SetupSuite()
+	capacity := int64(1)
+	rate := time.Second
+	clock := newFakeClock()
+	buckets := s.tokenBuckets(capacity, rate, clock)
+	for name, bucket := range buckets {
+		b.Run(name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_, err := bucket.Limit(context.TODO())
+				s.Require().NoError(err)
+			}
+		})
+	}
+	s.TearDownSuite()
 }


### PR DESCRIPTION
Accidentally deleted the branch for https://github.com/mennanov/limiters/pull/57 so I just start over.

Add benchmarks so it will be easier to compare different implementations and evaluate future improvements.

- BenchmarkConcurrentBuffers
- BenchmarkFixedWindows
- BenchmarkLeakyBuckets
- BenchmarkSlidingWindows
- BenchmarkTokenBuckets

Split Makefile targets to run test and benchmark separately, and update README accordingly.

This change will double the build time on GitHub if we want to cover both tests and benchmarks. We can run only tests on GitHub if needed.