### PR TITLE
Change `id` type from `uint32` to `int64` in LockPostgreSQL

### DIFF
--- a/limiters_test.go
+++ b/limiters_test.go
@@ -145,13 +145,13 @@ func (s *LimitersTestSuite) lockers(generateKeys bool) map[string]l.DistLocker {
 	return lockers
 }
 
-func hash(s string) uint32 {
+func hash(s string) int64 {
 	h := fnv.New32a()
 	_, err := h.Write([]byte(s))
 	if err != nil {
 		panic(err)
 	}
-	return h.Sum32()
+	return int64(h.Sum32())
 }
 
 // distLockers returns distributed lockers only.

--- a/locks.go
+++ b/locks.go
@@ -193,12 +193,12 @@ func (l *LockMemcached) Unlock(ctx context.Context) error {
 // LockPostgreSQL is an implementation of the DistLocker interface using PostgreSQL's advisory lock.
 type LockPostgreSQL struct {
 	db *sql.DB
-	id uint32
+	id int64
 	tx *sql.Tx
 }
 
 // NewLockPostgreSQL creates a new LockPostgreSQL.
-func NewLockPostgreSQL(db *sql.DB, id uint32) *LockPostgreSQL {
+func NewLockPostgreSQL(db *sql.DB, id int64) *LockPostgreSQL {
 	return &LockPostgreSQL{db, id, nil}
 }
 


### PR DESCRIPTION
- pg_advisory_xact_lock() accepts either a single bigint argument or two integer arguments.
  - https://www.postgresql.org/docs/16/functions-admin.html
- There is no need to limit the variable id passed to pg_advisory_xact_lock to uint32; I would like to change it to int64 to handle a wider range of values.
 