### PR TITLE
feat: Added Reset to TokenBucket

### DIFF
--- a/tokenbucket_test.go
+++ b/tokenbucket_test.go
@@ -213,8 +213,8 @@ func (s *LimitersTestSuite) TestTokenBucketReset() {
 			bucketCapacity := 2
 			bucket := l.NewTokenBucket(int64(bucketCapacity), time.Second*1, l.NewLockNoop(), backend, clock, s.logger)
 
-			// Check while Bucket is full, partial, empty
-			noOfAccess := []int{0, 1, 2, 3}
+			// Check while Bucket is full, partially full and empty
+			noOfAccess := 4
 
 			for access := range noOfAccess {
 				clock.reset()
@@ -224,7 +224,6 @@ func (s *LimitersTestSuite) TestTokenBucketReset() {
 					// Handle err when bucket capacity is reached
 					if i >= bucketCapacity {
 						s.Require().Equal(l.ErrLimitExhausted, err)
-						continue
 					} else {
 						s.Require().NoError(err)
 					}


### PR DESCRIPTION
### Motivation
Added new Reset feature to reset the state of the bucket
Fixes #19 

### Description
Reset allows the state of the bucket to be set to zero value.

Implementation done for
- [x] TokenBucket
- [ ] LeakyBucket
- [ ] Fixed Window
- [ ] Sliding Window
- [ ] Concurrent Buffer