### PR TITLE
add goimports

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,6 @@ linters:
     - godot
     - godox
     - gofumpt
-    - goimports
     - gomoddirectives
     - gosec
     - inamedparam

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: lint test benchmark
+all: goimports lint test benchmark
 
 docker-compose-up:
 	docker compose up -d
@@ -12,3 +12,7 @@ benchmark: docker-compose-up
 lint:
 	@which golangci-lint 2>&1 > /dev/null || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.7
 	golangci-lint run ./...
+
+goimports:
+	@which goimports 2>&1 > /dev/null || go install golang.org/x/tools/cmd/goimports@latest
+	goimports -w .

--- a/examples/gprc_service.go
+++ b/examples/gprc_service.go
@@ -2,6 +2,7 @@ package examples
 
 import (
 	"context"
+
 	pb "github.com/mennanov/limiters/examples/helloworld"
 )
 

--- a/examples/helloworld/helloworld.pb.go
+++ b/examples/helloworld/helloworld.pb.go
@@ -7,10 +7,11 @@
 package helloworld
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/examples/helloworld/helloworld_grpc.pb.go
+++ b/examples/helloworld/helloworld_grpc.pb.go
@@ -8,6 +8,7 @@ package helloworld
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/locks.go
+++ b/locks.go
@@ -3,7 +3,9 @@ package limiters
 import (
 	"context"
 	"database/sql"
-	"github.com/alessandro-c/gomemcached-lock"
+	"time"
+
+	lock "github.com/alessandro-c/gomemcached-lock"
 	"github.com/alessandro-c/gomemcached-lock/adapters/gomemcache"
 	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/cenkalti/backoff/v3"
@@ -15,7 +17,6 @@ import (
 	"github.com/samuel/go-zookeeper/zk"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
-	"time"
 )
 
 // DistLocker is a context aware distributed locker (interface is similar to sync.Locker).


### PR DESCRIPTION
Some linters are very useful and helpful, and others are just personal preference.

We can use this PR as an example about how to fix linter violations.

1. remove one linter from `disable` list in `.golangci.yml`, for example `goimports`
2. run `make lint` to see why it fails. It says `locks.go:6:1: File is not properly formatted (goimports)`
3. investigate and see why it fails. goimports want to group and sort the imports
4. fix them one by one, or install a tool to automate that
5. repeat step 2-4 till there is no more error.