### PR TITLE
fix err113 and errorlint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,8 +5,6 @@ linters:
     - depguard
     - dupl
     - dupword
-    - err113
-    - errorlint
     - exhaustruct
     - forcetypeassert
     - funlen

--- a/slidingwindow.go
+++ b/slidingwindow.go
@@ -145,9 +145,9 @@ func (s *SlidingWindowRedis) Increment(ctx context.Context, prev, curr time.Time
 	var prevCount int64
 	select {
 	case <-done:
-		if err == redis.TxFailedErr {
+		if errors.Is(err, redis.TxFailedErr) {
 			return 0, 0, errors.Wrap(err, "redis transaction failed")
-		} else if err == redis.Nil {
+		} else if errors.Is(err, redis.Nil) {
 			prevCount = 0
 		} else if err != nil {
 			return 0, 0, errors.Wrap(err, "unexpected error from redis")


### PR DESCRIPTION
[err113](https://github.com/Djarvur/go-err113) and [errorlint](https://github.com/polyfloyd/go-errorlint) both say that we shouldn't use `==` or `!=` to check against non-nil values.

We should use `errors.Is()` instead.