### PR TITLE
Coding style fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,11 +8,9 @@ linters:
     - exhaustruct
     - forcetypeassert
     - funlen
-    - gci
     - gochecknoglobals
     - goconst
     - gocritic
-    - godot
     - godox
     - gomoddirectives
     - gosec
@@ -21,7 +19,6 @@ linters:
     - lll
     - mnd
     - musttag
-    - nlreturn
     - paralleltest
     - perfsprint
     - recvcheck
@@ -32,6 +29,5 @@ linters:
     - testifylint
     - unparam
     - varnamelen
-    - whitespace
     - wrapcheck
     - wsl

--- a/concurrent_buffer_test.go
+++ b/concurrent_buffer_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-
 	l "github.com/mennanov/limiters"
 )
 

--- a/cosmos_test.go
+++ b/cosmos_test.go
@@ -33,6 +33,7 @@ func CreateCosmosDBContainer(ctx context.Context, client *azcosmos.Client) error
 			Paths: []string{`/partitionKey`},
 		},
 	}, &azcosmos.CreateContainerOptions{})
+
 	return err
 }
 
@@ -43,5 +44,6 @@ func DeleteCosmosDBContainer(ctx context.Context, client *azcosmos.Client) error
 	}
 
 	_, err = dbClient.Delete(ctx, &azcosmos.DeleteDatabaseOptions{})
+
 	return err
 }

--- a/dynamodb.go
+++ b/dynamodb.go
@@ -24,7 +24,7 @@ type DynamoDBTableProperties struct {
 	TTLFieldName string
 }
 
-// LoadDynamoDBTableProperties fetches a table description with the supplied client and returns a DynamoDBTableProperties struct
+// LoadDynamoDBTableProperties fetches a table description with the supplied client and returns a DynamoDBTableProperties struct.
 func LoadDynamoDBTableProperties(ctx context.Context, client *dynamodb.Client, tableName string) (DynamoDBTableProperties, error) {
 	resp, err := client.DescribeTable(ctx, &dynamodb.DescribeTableInput{
 		TableName: &tableName,
@@ -65,6 +65,7 @@ func loadTableKeys(data DynamoDBTableProperties, table *types.TableDescription) 
 	for _, key := range table.KeySchema {
 		if key.KeyType == types.KeyTypeHash {
 			data.PartitionKeyName = *key.AttributeName
+
 			continue
 		}
 

--- a/fixedwindow.go
+++ b/fixedwindow.go
@@ -70,8 +70,10 @@ func (f *FixedWindow) Limit(ctx context.Context) (time.Duration, error) {
 	}
 	if c > f.capacity {
 		f.overflow = true
+
 		return ttl, ErrLimitExhausted
 	}
+
 	return 0, nil
 }
 
@@ -96,6 +98,7 @@ func (f *FixedWindowInMemory) Increment(ctx context.Context, window time.Time, _
 		f.window = window
 	}
 	f.c++
+
 	return f.c, ctx.Err()
 }
 
@@ -122,6 +125,7 @@ func (f *FixedWindowRedis) Increment(ctx context.Context, window time.Time, ttl 
 			key := fmt.Sprintf("%d", window.UnixNano())
 			incr = pipeliner.Incr(ctx, redisKey(f.prefix, key))
 			pipeliner.PExpire(ctx, redisKey(f.prefix, key), ttl)
+
 			return nil
 		})
 	}()
@@ -131,6 +135,7 @@ func (f *FixedWindowRedis) Increment(ctx context.Context, window time.Time, ttl 
 		if err != nil {
 			return 0, errors.Wrap(err, "redis transaction failed")
 		}
+
 		return incr.Val(), incr.Err()
 	case <-ctx.Done():
 		return 0, ctx.Err()
@@ -174,8 +179,10 @@ func (f *FixedWindowMemcached) Increment(ctx context.Context, window time.Time, 
 			if errors.Is(err, memcache.ErrNotStored) {
 				return f.Increment(ctx, window, ttl)
 			}
+
 			return 0, errors.Wrap(err, "failed to Increment or Add")
 		}
+
 		return int64(newValue), err
 	case <-ctx.Done():
 		return 0, ctx.Err()
@@ -194,7 +201,7 @@ type FixedWindowDynamoDB struct {
 //
 // TableProps describe the table that this backend should work with. This backend requires the following on the table:
 // * SortKey
-// * TTL
+// * TTL.
 func NewFixedWindowDynamoDB(client *dynamodb.Client, partitionKey string, props DynamoDBTableProperties) *FixedWindowDynamoDB {
 	return &FixedWindowDynamoDB{
 		client:       client,
@@ -306,6 +313,7 @@ func (f *FixedWindowCosmosDB) Increment(ctx context.Context, window time.Time, t
 		if err != nil {
 			return 0, errors.Wrap(err, "unmarshal of cosmos value failed")
 		}
+
 		return tmp.Count, nil
 	}
 

--- a/fixedwindow_test.go
+++ b/fixedwindow_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-
 	l "github.com/mennanov/limiters"
 )
 
@@ -16,6 +15,7 @@ func (s *LimitersTestSuite) fixedWindows(capacity int64, rate time.Duration, clo
 	for name, inc := range s.fixedWindowIncrementers() {
 		windows[name] = l.NewFixedWindow(capacity, rate, inc, clock)
 	}
+
 	return windows
 }
 

--- a/leakybucket_test.go
+++ b/leakybucket_test.go
@@ -21,6 +21,7 @@ func (s *LimitersTestSuite) leakyBuckets(capacity int64, rate time.Duration, clo
 			buckets[lockerName+":"+backendName] = l.NewLeakyBucket(capacity, rate, locker, backend, clock, s.logger)
 		}
 	}
+
 	return buckets
 }
 
@@ -201,14 +202,16 @@ func BenchmarkLeakyBuckets(b *testing.B) {
 	s.TearDownSuite()
 }
 
-// setStateInOldFormat is a test utility method for writing state in the old format to Redis
+// setStateInOldFormat is a test utility method for writing state in the old format to Redis.
 func setStateInOldFormat(ctx context.Context, cli *redis.Client, prefix string, state l.LeakyBucketState, ttl time.Duration) error {
 	_, err := cli.TxPipelined(ctx, func(pipeliner redis.Pipeliner) error {
 		if err := pipeliner.Set(ctx, fmt.Sprintf("{%s}last", prefix), state.Last, ttl).Err(); err != nil {
 			return err
 		}
+
 		return nil
 	})
+
 	return err
 }
 

--- a/limiters.go
+++ b/limiters.go
@@ -35,7 +35,7 @@ func (l *StdLogger) Log(v ...interface{}) {
 }
 
 // Clock encapsulates a system Clock.
-// Used
+// Used.
 type Clock interface {
 	// Now returns the current system time.
 	Now() time.Time

--- a/limiters_test.go
+++ b/limiters_test.go
@@ -20,12 +20,11 @@ import (
 	"github.com/go-redsync/redsync/v4/redis/goredis/v9"
 	"github.com/google/uuid"
 	"github.com/hashicorp/consul/api"
+	l "github.com/mennanov/limiters"
 	"github.com/redis/go-redis/v9"
 	"github.com/samuel/go-zookeeper/zk"
 	"github.com/stretchr/testify/suite"
 	clientv3 "go.etcd.io/etcd/client/v3"
-
-	l "github.com/mennanov/limiters"
 )
 
 type fakeClock struct {
@@ -36,6 +35,7 @@ type fakeClock struct {
 
 func newFakeClock() *fakeClock {
 	now := time.Now()
+
 	return &fakeClock{t: now, initial: now}
 }
 
@@ -46,6 +46,7 @@ func newFakeClockWithTime(t time.Time) *fakeClock {
 func (c *fakeClock) Now() time.Time {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
 	return c.t
 }
 
@@ -158,6 +159,7 @@ func TestLimitersTestSuite(t *testing.T) {
 func (s *LimitersTestSuite) lockers(generateKeys bool) map[string]l.DistLocker {
 	lockers := s.distLockers(generateKeys)
 	lockers["LockNoop"] = l.NewLockNoop()
+
 	return lockers
 }
 
@@ -167,6 +169,7 @@ func hash(s string) int64 {
 	if err != nil {
 		panic(err)
 	}
+
 	return int64(h.Sum32())
 }
 
@@ -189,6 +192,7 @@ func (s *LimitersTestSuite) distLockers(generateKeys bool) map[string]l.DistLock
 	}
 	consulLock, err := s.consulClient.LockKey(consulKey)
 	s.Require().NoError(err)
+
 	return map[string]l.DistLocker{
 		"LockEtcd":         l.NewLockEtcd(s.etcdClient, etcdKey, s.logger),
 		"LockConsul":       l.NewLockConsul(consulLock),

--- a/registry.go
+++ b/registry.go
@@ -42,6 +42,7 @@ func (pq *gcPq) Pop() interface{} {
 	item := old[n-1]
 	item.index = -1 // for safety
 	*pq = old[0 : n-1]
+
 	return item
 }
 
@@ -56,6 +57,7 @@ type Registry struct {
 // NewRegistry creates a new instance of Registry.
 func NewRegistry() *Registry {
 	pq := make(gcPq, 0)
+
 	return &Registry{pq: &pq, m: make(map[string]*pqItem)}
 }
 
@@ -99,6 +101,7 @@ func (r *Registry) DeleteExpired(now time.Time) int {
 		heap.Pop(r.pq)
 		c++
 	}
+
 	return c
 }
 
@@ -119,6 +122,7 @@ func (r *Registry) Exists(key string) bool {
 	r.mx.Lock()
 	defer r.mx.Unlock()
 	_, ok := r.m[key]
+
 	return ok
 }
 
@@ -126,5 +130,6 @@ func (r *Registry) Exists(key string) bool {
 func (r *Registry) Len() int {
 	r.mx.Lock()
 	defer r.mx.Unlock()
+
 	return len(*r.pq)
 }

--- a/registry_test.go
+++ b/registry_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mennanov/limiters"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/mennanov/limiters"
 )
 
 type testingLimiter struct{}
@@ -30,6 +29,7 @@ func TestRegistry_GetOrCreate(t *testing.T) {
 	limiter := newTestingLimiter()
 	l := registry.GetOrCreate("key", func() interface{} {
 		called = true
+
 		return limiter
 	}, time.Second, clock.Now())
 	assert.Equal(t, limiter, l)
@@ -38,6 +38,7 @@ func TestRegistry_GetOrCreate(t *testing.T) {
 	called = false
 	l = registry.GetOrCreate("key", func() interface{} {
 		called = true
+
 		return newTestingLimiter()
 	}, time.Second, clock.Now())
 	assert.Equal(t, limiter, l)

--- a/slidingwindow_test.go
+++ b/slidingwindow_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-
 	l "github.com/mennanov/limiters"
 )
 
@@ -16,6 +15,7 @@ func (s *LimitersTestSuite) slidingWindows(capacity int64, rate time.Duration, c
 	for name, inc := range s.slidingWindowIncrementers() {
 		windows[name] = l.NewSlidingWindow(capacity, rate, inc, clock, epsilon)
 	}
+
 	return windows
 }
 

--- a/tokenbucket_test.go
+++ b/tokenbucket_test.go
@@ -78,6 +78,7 @@ func (s *LimitersTestSuite) tokenBuckets(capacity int64, refillRate time.Duratio
 			buckets[lockerName+":"+backendName] = l.NewTokenBucket(capacity, refillRate, locker, backend, clock, s.logger)
 		}
 	}
+
 	return buckets
 }
 
@@ -235,7 +236,7 @@ func (s *LimitersTestSuite) TestTokenBucketRefill() {
 	}
 }
 
-// setTokenBucketStateInOldFormat is a test utility method for writing state in the old format to Redis
+// setTokenBucketStateInOldFormat is a test utility method for writing state in the old format to Redis.
 func setTokenBucketStateInOldFormat(ctx context.Context, cli *redis.Client, prefix string, state l.TokenBucketState, ttl time.Duration) error {
 	_, err := cli.TxPipelined(ctx, func(pipeliner redis.Pipeliner) error {
 		if err := pipeliner.Set(ctx, fmt.Sprintf("{%s}last", prefix), state.Last, ttl).Err(); err != nil {
@@ -244,8 +245,10 @@ func setTokenBucketStateInOldFormat(ctx context.Context, cli *redis.Client, pref
 		if err := pipeliner.Set(ctx, fmt.Sprintf("{%s}available", prefix), state.Available, ttl).Err(); err != nil {
 			return err
 		}
+
 		return nil
 	})
+
 	return err
 }
 


### PR DESCRIPTION
Coding style fixes.

- [whitespace](https://github.com/ultraware/whitespace): removes unnecessary newlines
- [nlreturn](https://github.com/ssgreg/nlreturn): requires a new line before return
- [godot](https://github.com/tetafro/godot): checks if all top-level comments contain a period at the end of the last sentence
- [gci](https://github.com/daixiang0/gci): controls Go package import order 