### PR TITLE
fix(fixedwindow): make fixed window partition aware

### DIFF
--- a/fixedwindow_test.go
+++ b/fixedwindow_test.go
@@ -116,6 +116,8 @@ func (s *LimitersTestSuite) TestFixedWindowDynamoDBPartitionKey() {
 	w, err = window.Limit(context.TODO())
 	s.Require().NoError(err)
 	s.Equal(time.Duration(0), w)
+	w, err = window.Limit(context.TODO())
+	s.Require().Error(err)
 	// The third call should fail for the "partitionKey1", but succeed for "partitionKey2".
 	w, err = window.Limit(l.NewFixedWindowDynamoDBContext(context.Background(), "partitionKey2"))
 	s.Require().NoError(err)

--- a/fixedwindow_test.go
+++ b/fixedwindow_test.go
@@ -118,6 +118,7 @@ func (s *LimitersTestSuite) TestFixedWindowDynamoDBPartitionKey() {
 	s.Equal(time.Duration(0), w)
 	w, err = window.Limit(context.TODO())
 	s.Require().Error(err)
+	s.Equal(time.Millisecond*100, w)
 	// The third call should fail for the "partitionKey1", but succeed for "partitionKey2".
 	w, err = window.Limit(l.NewFixedWindowDynamoDBContext(context.Background(), "partitionKey2"))
 	s.Require().NoError(err)


### PR DESCRIPTION
Partition key support was added to DynamoDB fixed window implementation but the generic limit functionality is not aware of is and leads to caching overflow state for all partition keys. This means that if single partition key overflows, all other partition keys are treated as overflowed as well. This change makes so that overflow is aware of partition key.