### PR TITLE
fix: set expiry on state stored in Memcached

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -23,4 +23,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: latest
+          version: "v2.1.6"

--- a/leakybucket.go
+++ b/leakybucket.go
@@ -586,9 +586,10 @@ func (t *LeakyBucketMemcached) SetState(ctx context.Context, state LeakyBucketSt
 	go func() {
 		defer close(done)
 		item := &memcache.Item{
-			Key:   t.key,
-			Value: b.Bytes(),
-			CasID: t.casId,
+			Key:        t.key,
+			Value:      b.Bytes(),
+			CasID:      t.casId,
+			Expiration: int32(t.ttl.Seconds()),
 		}
 		if t.raceCheck && t.casId > 0 {
 			err = t.cli.CompareAndSwap(item)

--- a/leakybucket.go
+++ b/leakybucket.go
@@ -589,7 +589,7 @@ func (t *LeakyBucketMemcached) SetState(ctx context.Context, state LeakyBucketSt
 			Key:        t.key,
 			Value:      b.Bytes(),
 			CasID:      t.casId,
-			Expiration: int32(t.ttl.Seconds()),
+			Expiration: int32(time.Now().Add(t.ttl).Unix()),
 		}
 		if t.raceCheck && t.casId > 0 {
 			err = t.cli.CompareAndSwap(item)

--- a/tokenbucket.go
+++ b/tokenbucket.go
@@ -690,9 +690,10 @@ func (t *TokenBucketMemcached) SetState(ctx context.Context, state TokenBucketSt
 	go func() {
 		defer close(done)
 		item := &memcache.Item{
-			Key:   t.key,
-			Value: b.Bytes(),
-			CasID: t.casId,
+			Key:        t.key,
+			Value:      b.Bytes(),
+			CasID:      t.casId,
+			Expiration: int32(time.Now().Add(t.ttl).Unix()),
 		}
 		if t.raceCheck && t.casId > 0 {
 			err = t.cli.CompareAndSwap(item)


### PR DESCRIPTION
There is no expiry set on the state stored in the Memcached implementation of the leaky bucket. While this may not be a functional problem on a long enough time scale (due to how Memcached treats eviction), but it would be at least intuitive for the expiration to honor the TTL passed into the leaky bucket implementation.

This also hard-codes the linter version to remove linting failures raised by changes introduced into golangci-lint in between the last version that successfully linted this project (v2.1.6) and the current release (v2.2.1).