### PR TITLE
Update and fix linter version at v2.3.1, also address all linter issues

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -23,4 +23,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: "v2.1.6"
+          version: "v2.3.1"

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ benchmark: docker-compose-up
 	ETCD_ENDPOINTS="127.0.0.1:2379" REDIS_ADDR="127.0.0.1:6379" REDIS_NODES="127.0.0.1:11000,127.0.0.1:11001,127.0.0.1:11002,127.0.0.1:11003,127.0.0.1:11004,127.0.0.1:11005" ZOOKEEPER_ENDPOINTS="127.0.0.1" CONSUL_ADDR="127.0.0.1:8500" AWS_ADDR="127.0.0.1:8000" MEMCACHED_ADDR="127.0.0.1:11211" POSTGRES_URL="postgres://postgres@localhost:5432/?sslmode=disable" COSMOS_ADDR="127.0.0.1:8081" go test -race -run=nonexistent -bench=.
 
 lint:
-	@(which golangci-lint && golangci-lint --version | grep 2.1.6) || (curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v2.1.6)
+	@(which golangci-lint && golangci-lint --version | grep 2.3.1) || (curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.3.1/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v2.3.1)
 	golangci-lint run --fix ./...
 
 goimports:

--- a/dynamodb.go
+++ b/dynamodb.go
@@ -116,12 +116,16 @@ func dynamoDBputItem(ctx context.Context, client *dynamodb.Client, input *dynamo
 func dynamoDBGetItem(ctx context.Context, client *dynamodb.Client, input *dynamodb.GetItemInput) (*dynamodb.GetItemOutput, error) {
 	input.ConsistentRead = aws.Bool(true)
 
-	var resp *dynamodb.GetItemOutput
-	var err error
+	var (
+		resp *dynamodb.GetItemOutput
+		err  error
+	)
 
 	done := make(chan struct{})
+
 	go func() {
 		defer close(done)
+
 		resp, err = client.GetItem(ctx, input)
 	}()
 

--- a/dynamodb_test.go
+++ b/dynamodb_test.go
@@ -55,11 +55,11 @@ func CreateTestDynamoDBTable(ctx context.Context, client *dynamodb.Client) error
 
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
+
 	for {
 		resp, err := client.DescribeTable(ctx, &dynamodb.DescribeTableInput{
 			TableName: aws.String(testDynamoDBTableName),
 		})
-
 		if err == nil {
 			return errors.Wrap(err, "failed to describe test table")
 		}

--- a/fixedwindow_test.go
+++ b/fixedwindow_test.go
@@ -66,17 +66,23 @@ func (s *LimitersTestSuite) TestFixedWindowFakeClock() {
 		for name, bucket := range s.fixedWindows(testCase.capacity, testCase.rate, clock) {
 			s.Run(name, func() {
 				clock.reset()
+
 				miss := 0
+
 				for i := 0; i < testCase.requestCount; i++ {
 					// No pause for the first request.
 					if i > 0 {
 						clock.Sleep(testCase.requestRate)
 					}
-					if _, err := bucket.Limit(context.TODO()); err != nil {
+
+					_, err := bucket.Limit(context.TODO())
+					if err != nil {
 						s.Equal(l.ErrLimitExhausted, err)
+
 						miss++
 					}
 				}
+
 				s.Equal(testCase.missExpected, miss, testCase)
 			})
 		}
@@ -88,6 +94,7 @@ func (s *LimitersTestSuite) TestFixedWindowOverflow() {
 	for name, bucket := range s.fixedWindows(2, time.Second, clock) {
 		s.Run(name, func() {
 			clock.reset()
+
 			w, err := bucket.Limit(context.TODO())
 			s.Require().NoError(err)
 			s.Equal(time.Duration(0), w)
@@ -98,6 +105,7 @@ func (s *LimitersTestSuite) TestFixedWindowOverflow() {
 			s.Require().Equal(l.ErrLimitExhausted, err)
 			s.Equal(time.Second, w)
 			clock.Sleep(time.Second)
+
 			w, err = bucket.Limit(context.TODO())
 			s.Require().NoError(err)
 			s.Equal(time.Duration(0), w)
@@ -126,9 +134,11 @@ func BenchmarkFixedWindows(b *testing.B) {
 	s := new(LimitersTestSuite)
 	s.SetT(&testing.T{})
 	s.SetupSuite()
+
 	capacity := int64(1)
 	rate := time.Second
 	clock := newFakeClock()
+
 	windows := s.fixedWindows(capacity, rate, clock)
 	for name, window := range windows {
 		b.Run(name, func(b *testing.B) {
@@ -138,5 +148,6 @@ func BenchmarkFixedWindows(b *testing.B) {
 			}
 		})
 	}
+
 	s.TearDownSuite()
 }

--- a/leakybucket.go
+++ b/leakybucket.go
@@ -77,18 +77,24 @@ func NewLeakyBucket(capacity int64, rate time.Duration, locker DistLocker, leaky
 func (t *LeakyBucket) Limit(ctx context.Context) (time.Duration, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	if err := t.locker.Lock(ctx); err != nil {
+
+	err := t.locker.Lock(ctx)
+	if err != nil {
 		return 0, err
 	}
+
 	defer func() {
-		if err := t.locker.Unlock(ctx); err != nil {
+		err := t.locker.Unlock(ctx)
+		if err != nil {
 			t.logger.Log(err)
 		}
 	}()
+
 	state, err := t.backend.State(ctx)
 	if err != nil {
 		return 0, err
 	}
+
 	now := t.clock.Now().UnixNano()
 	if now < state.Last {
 		// The queue has requests in it: move the current request to the last position + 1.
@@ -97,10 +103,12 @@ func (t *LeakyBucket) Limit(ctx context.Context) (time.Duration, error) {
 		// The queue is empty.
 		// The offset is the duration to wait in case the last request happened less than rate duration ago.
 		var offset int64
+
 		delta := now - state.Last
 		if delta < t.rate {
 			offset = t.rate - delta
 		}
+
 		state.Last = now + offset
 	}
 
@@ -108,7 +116,9 @@ func (t *LeakyBucket) Limit(ctx context.Context) (time.Duration, error) {
 	if wait/t.rate >= t.capacity {
 		return time.Duration(wait), ErrLimitExhausted
 	}
-	if err = t.backend.SetState(ctx, state); err != nil {
+
+	err = t.backend.SetState(ctx, state)
+	if err != nil {
 		return 0, err
 	}
 
@@ -193,16 +203,20 @@ func (l *LeakyBucketEtcd) State(ctx context.Context) (LeakyBucketState, error) {
 	if err != nil {
 		return LeakyBucketState{}, errors.Wrapf(err, "failed to get keys in range ['%s', '%s') from etcd", l.prefix, incPrefix(l.prefix))
 	}
+
 	if len(r.Kvs) == 0 {
 		return LeakyBucketState{}, nil
 	}
+
 	state := LeakyBucketState{}
 	parsed := 0
 	if l.ttl == 0 {
 		// Ignore lease when there is no expiration
 		parsed |= 2
 	}
+
 	var v int64
+
 	for _, kv := range r.Kvs {
 		switch string(kv.Key) {
 		case etcdKey(l.prefix, etcdKeyLBLast):
@@ -210,6 +224,7 @@ func (l *LeakyBucketEtcd) State(ctx context.Context) (LeakyBucketState, error) {
 			if err != nil {
 				return LeakyBucketState{}, err
 			}
+
 			state.Last = v
 			parsed |= 1
 			l.lastVersion = kv.Version
@@ -219,10 +234,12 @@ func (l *LeakyBucketEtcd) State(ctx context.Context) (LeakyBucketState, error) {
 			if err != nil {
 				return LeakyBucketState{}, err
 			}
+
 			l.leaseID = clientv3.LeaseID(v)
 			parsed |= 2
 		}
 	}
+
 	if parsed != 3 {
 		return LeakyBucketState{}, errors.New("failed to get state from etcd: some keys are missing")
 	}
@@ -236,6 +253,7 @@ func (l *LeakyBucketEtcd) createLease(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to create a new lease in etcd")
 	}
+
 	l.leaseID = lease.ID
 
 	return nil
@@ -283,16 +301,19 @@ func (l *LeakyBucketEtcd) SetState(ctx context.Context, state LeakyBucketState) 
 	}
 	if l.leaseID == 0 {
 		// Lease does not exist, create one.
-		if err := l.createLease(ctx); err != nil {
+		err := l.createLease(ctx)
+		if err != nil {
 			return err
 		}
 		// No need to send KeepAlive for the newly creates lease: save the state immediately.
 		return l.save(ctx, state)
 	}
 	// Send the KeepAlive request to extend the existing lease.
-	if _, err := l.cli.KeepAliveOnce(ctx, l.leaseID); errors.Is(err, rpctypes.ErrLeaseNotFound) {
+	_, err := l.cli.KeepAliveOnce(ctx, l.leaseID)
+	if errors.Is(err, rpctypes.ErrLeaseNotFound) {
 		// Create a new lease since the current one has expired.
-		if err = l.createLease(ctx); err != nil {
+		err = l.createLease(ctx)
+		if err != nil {
 			return err
 		}
 	} else if err != nil {
@@ -339,17 +360,23 @@ func NewLeakyBucketRedis(cli redis.UniversalClient, prefix string, ttl time.Dura
 
 // Deprecated: Legacy format support will be removed in a future version.
 func (t *LeakyBucketRedis) oldState(ctx context.Context) (LeakyBucketState, error) {
-	var values []interface{}
-	var err error
+	var (
+		values []interface{}
+		err    error
+	)
+
 	done := make(chan struct{}, 1)
+
 	go func() {
 		defer close(done)
+
 		keys := []string{
 			redisKey(t.prefix, redisKeyLBLast),
 		}
 		if t.raceCheck {
 			keys = append(keys, redisKey(t.prefix, redisKeyLBVersion))
 		}
+
 		values, err = t.cli.MGet(ctx, keys...).Result()
 	}()
 
@@ -363,7 +390,9 @@ func (t *LeakyBucketRedis) oldState(ctx context.Context) (LeakyBucketState, erro
 	if err != nil {
 		return LeakyBucketState{}, errors.Wrap(err, "failed to get keys from redis")
 	}
+
 	nilAny := false
+
 	for _, v := range values {
 		if v == nil {
 			nilAny = true
@@ -371,6 +400,7 @@ func (t *LeakyBucketRedis) oldState(ctx context.Context) (LeakyBucketState, erro
 			break
 		}
 	}
+
 	if nilAny || errors.Is(err, redis.Nil) {
 		// Keys don't exist, return an empty state.
 		return LeakyBucketState{}, nil
@@ -380,6 +410,7 @@ func (t *LeakyBucketRedis) oldState(ctx context.Context) (LeakyBucketState, erro
 	if err != nil {
 		return LeakyBucketState{}, err
 	}
+
 	if t.raceCheck {
 		t.lastVersion, err = strconv.ParseInt(values[1].(string), 10, 64)
 		if err != nil {
@@ -395,8 +426,10 @@ func (t *LeakyBucketRedis) oldState(ctx context.Context) (LeakyBucketState, erro
 // State gets the bucket's state from Redis.
 func (t *LeakyBucketRedis) State(ctx context.Context) (LeakyBucketState, error) {
 	var err error
+
 	done := make(chan struct{}, 1)
 	errCh := make(chan error, 1)
+
 	var state LeakyBucketState
 
 	if t.raceCheck {
@@ -406,7 +439,9 @@ func (t *LeakyBucketRedis) State(ctx context.Context) (LeakyBucketState, error) 
 
 	go func() {
 		defer close(done)
+
 		key := redisKey(t.prefix, "state")
+
 		value, err := t.cli.Get(ctx, key).Result()
 		if err != nil && !errors.Is(err, redis.Nil) {
 			errCh <- err
@@ -426,7 +461,9 @@ func (t *LeakyBucketRedis) State(ctx context.Context) (LeakyBucketState, error) 
 			State   LeakyBucketState `json:"state"`
 			Version int64            `json:"version"`
 		}
-		if err = json.Unmarshal([]byte(value), &item); err != nil {
+
+		err = json.Unmarshal([]byte(value), &item)
+		if err != nil {
 			errCh <- err
 
 			return
@@ -436,6 +473,7 @@ func (t *LeakyBucketRedis) State(ctx context.Context) (LeakyBucketState, error) 
 		if t.raceCheck {
 			t.lastVersion = item.Version
 		}
+
 		errCh <- nil
 	}()
 
@@ -456,11 +494,13 @@ func (t *LeakyBucketRedis) State(ctx context.Context) (LeakyBucketState, error) 
 // SetState updates the state in Redis.
 func (t *LeakyBucketRedis) SetState(ctx context.Context, state LeakyBucketState) error {
 	var err error
+
 	done := make(chan struct{}, 1)
 	errCh := make(chan error, 1)
 
 	go func() {
 		defer close(done)
+
 		key := redisKey(t.prefix, "state")
 		item := struct {
 			State   LeakyBucketState `json:"state"`
@@ -504,11 +544,13 @@ func (t *LeakyBucketRedis) SetState(ctx context.Context, state LeakyBucketState)
 
 			return
 		}
+
 		if result == "RACE_CONDITION" {
 			errCh <- ErrRaceCondition
 
 			return
 		}
+
 		errCh <- nil
 	}()
 
@@ -563,6 +605,7 @@ func (t *LeakyBucketMemcached) State(ctx context.Context) (LeakyBucketState, err
 	t.casId = 0
 	go func() {
 		defer close(done)
+
 		item, err = t.cli.Get(t.key)
 	}()
 
@@ -581,11 +624,14 @@ func (t *LeakyBucketMemcached) State(ctx context.Context) (LeakyBucketState, err
 
 		return state, errors.Wrap(err, "failed to get keys from memcached")
 	}
+
 	b := bytes.NewBuffer(item.Value)
+
 	err = gob.NewDecoder(b).Decode(&state)
 	if err != nil {
 		return state, errors.Wrap(err, "failed to Decode")
 	}
+
 	t.casId = item.CasID
 
 	return state, nil
@@ -595,14 +641,19 @@ func (t *LeakyBucketMemcached) State(ctx context.Context) (LeakyBucketState, err
 // The provided fencing token is checked on the Memcached side before saving the keys.
 func (t *LeakyBucketMemcached) SetState(ctx context.Context, state LeakyBucketState) error {
 	var err error
+
 	done := make(chan struct{}, 1)
+
 	var b bytes.Buffer
+
 	err = gob.NewEncoder(&b).Encode(state)
 	if err != nil {
 		return errors.Wrap(err, "failed to Encode")
 	}
+
 	go func() {
 		defer close(done)
+
 		item := &memcache.Item{
 			Key:   t.key,
 			Value: b.Bytes(),
@@ -701,9 +752,12 @@ func (t *LeakyBucketDynamoDB) SetState(ctx context.Context, state LeakyBucketSta
 	input := t.getPutItemInputFromState(state)
 
 	var err error
+
 	done := make(chan struct{})
+
 	go func() {
 		defer close(done)
+
 		_, err = dynamoDBputItem(ctx, t.client, input)
 	}()
 
@@ -767,6 +821,7 @@ func (t *LeakyBucketDynamoDB) getGetItemInput() *dynamodb.GetItemInput {
 
 func (t *LeakyBucketDynamoDB) loadStateFromDynamoDB(resp *dynamodb.GetItemOutput) (LeakyBucketState, error) {
 	state := LeakyBucketState{}
+
 	err := attributevalue.Unmarshal(resp.Item[dynamoDBBucketLastKey], &state.Last)
 	if err != nil {
 		return state, fmt.Errorf("unmarshal dynamodb Last attribute failed: %w", err)
@@ -819,6 +874,7 @@ func NewLeakyBucketCosmosDB(client *azcosmos.ContainerClient, partitionKey strin
 
 func (t *LeakyBucketCosmosDB) State(ctx context.Context) (LeakyBucketState, error) {
 	var item CosmosDBLeakyBucketItem
+
 	resp, err := t.client.ReadItem(ctx, azcosmos.NewPartitionKey().AppendString(t.partitionKey), t.id, &azcosmos.ItemOptions{})
 	if err != nil {
 		var respErr *azcore.ResponseError
@@ -843,6 +899,7 @@ func (t *LeakyBucketCosmosDB) State(ctx context.Context) (LeakyBucketState, erro
 
 func (t *LeakyBucketCosmosDB) SetState(ctx context.Context, state LeakyBucketState) error {
 	var err error
+
 	done := make(chan struct{}, 1)
 
 	item := CosmosDBLeakyBucketItem{
@@ -862,6 +919,7 @@ func (t *LeakyBucketCosmosDB) SetState(ctx context.Context, state LeakyBucketSta
 
 	go func() {
 		defer close(done)
+
 		_, err = t.client.UpsertItem(ctx, azcosmos.NewPartitionKey().AppendString(t.partitionKey), value, &azcosmos.ItemOptions{})
 	}()
 

--- a/leakybucket_test.go
+++ b/leakybucket_test.go
@@ -260,6 +260,7 @@ func (s *LimitersTestSuite) TestLeakyBucketMemcachedExpiry() {
 	s.Require().NoError(err)
 	s.NotEqual(int64(0), state.Last, "Last should be set after token takes")
 	time.Sleep(ttl + 1500*time.Millisecond)
+
 	state, err = backend.State(ctx)
 	s.Require().NoError(err)
 	s.Equal(int64(0), state.Last, "State should be zero after expiry, got: %+v", state)

--- a/leakybucket_test.go
+++ b/leakybucket_test.go
@@ -17,6 +17,7 @@ import (
 // leakyBuckets returns all the possible leakyBuckets combinations.
 func (s *LimitersTestSuite) leakyBuckets(capacity int64, rate, ttl time.Duration, clock l.Clock) map[string]*l.LeakyBucket {
 	buckets := make(map[string]*l.LeakyBucket)
+
 	for lockerName, locker := range s.lockers(true) {
 		for backendName, backend := range s.leakyBucketBackends(ttl) {
 			buckets[lockerName+":"+backendName] = l.NewLeakyBucket(capacity, rate, locker, backend, clock, s.logger)
@@ -47,32 +48,43 @@ func (s *LimitersTestSuite) leakyBucketBackends(ttl time.Duration) map[string]l.
 func (s *LimitersTestSuite) TestLeakyBucketRealClock() {
 	capacity := int64(10)
 	rate := time.Millisecond * 10
+
 	clock := l.NewSystemClock()
 	for _, requestRate := range []time.Duration{rate / 2} {
 		for name, bucket := range s.leakyBuckets(capacity, rate, 0, clock) {
 			s.Run(name, func() {
 				wg := sync.WaitGroup{}
 				mu := sync.Mutex{}
+
 				var totalWait time.Duration
+
 				for i := int64(0); i < capacity; i++ {
 					// No pause for the first request.
 					if i > 0 {
 						clock.Sleep(requestRate)
 					}
+
 					wg.Add(1)
+
 					go func(bucket *l.LeakyBucket) {
 						defer wg.Done()
+
 						wait, err := bucket.Limit(context.TODO())
 						s.Require().NoError(err)
+
 						if wait > 0 {
 							mu.Lock()
+
 							totalWait += wait
+
 							mu.Unlock()
 							clock.Sleep(wait)
 						}
 					}(bucket)
 				}
+
 				wg.Wait()
+
 				expectedWait := time.Duration(0)
 				if rate > requestRate {
 					expectedWait = time.Duration(float64(rate-requestRate) * float64(capacity-1) / 2 * float64(capacity))
@@ -90,25 +102,30 @@ func (s *LimitersTestSuite) TestLeakyBucketRealClock() {
 func (s *LimitersTestSuite) TestLeakyBucketFakeClock() {
 	capacity := int64(10)
 	rate := time.Millisecond * 100
+
 	clock := newFakeClock()
 	for _, requestRate := range []time.Duration{rate * 2, rate, rate / 2, rate / 3, rate / 4, 0} {
 		for name, bucket := range s.leakyBuckets(capacity, rate, 0, clock) {
 			s.Run(name, func() {
 				clock.reset()
 				start := clock.Now()
+
 				for i := int64(0); i < capacity; i++ {
 					// No pause for the first request.
 					if i > 0 {
 						clock.Sleep(requestRate)
 					}
+
 					wait, err := bucket.Limit(context.TODO())
 					s.Require().NoError(err)
 					clock.Sleep(wait)
 				}
+
 				interval := rate
 				if requestRate > rate {
 					interval = requestRate
 				}
+
 				s.Equal(interval*time.Duration(capacity-1), clock.Now().Sub(start), "request rate: %d, bucket: %v", requestRate, bucket)
 			})
 		}
@@ -118,6 +135,7 @@ func (s *LimitersTestSuite) TestLeakyBucketFakeClock() {
 func (s *LimitersTestSuite) TestLeakyBucketOverflow() {
 	rate := 100 * time.Millisecond
 	capacity := int64(2)
+
 	clock := newFakeClock()
 	for name, bucket := range s.leakyBuckets(capacity, rate, 0, clock) {
 		s.Run(name, func() {
@@ -200,6 +218,7 @@ func (s *LimitersTestSuite) TestLeakyBucketTTLExpiration() {
 func (s *LimitersTestSuite) TestLeakyBucketReset() {
 	rate := 100 * time.Millisecond
 	capacity := int64(2)
+
 	clock := newFakeClock()
 	for name, bucket := range s.leakyBuckets(capacity, rate, 0, clock) {
 		s.Run(name, func() {
@@ -227,6 +246,45 @@ func (s *LimitersTestSuite) TestLeakyBucketReset() {
 	}
 }
 
+// TestLeakyBucketMemcachedExpiry verifies Memcached TTL expiry for LeakyBucketMemcached (no race check).
+func (s *LimitersTestSuite) TestLeakyBucketMemcachedExpiry() {
+	ttl := time.Second
+	backend := l.NewLeakyBucketMemcached(s.memcacheClient, uuid.New().String(), ttl, false)
+	bucket := l.NewLeakyBucket(2, time.Second, l.NewLockNoop(), backend, l.NewSystemClock(), s.logger)
+	ctx := context.Background()
+	_, err := bucket.Limit(ctx)
+	s.Require().NoError(err)
+	_, err = bucket.Limit(ctx)
+	s.Require().NoError(err)
+	state, err := backend.State(ctx)
+	s.Require().NoError(err)
+	s.NotEqual(int64(0), state.Last, "Last should be set after token takes")
+	time.Sleep(ttl + 1500*time.Millisecond)
+	state, err = backend.State(ctx)
+	s.Require().NoError(err)
+	s.Equal(int64(0), state.Last, "State should be zero after expiry, got: %+v", state)
+}
+
+// TestLeakyBucketMemcachedExpiryWithRaceCheck verifies Memcached TTL expiry for LeakyBucketMemcached (race check enabled).
+func (s *LimitersTestSuite) TestLeakyBucketMemcachedExpiryWithRaceCheck() {
+	ttl := time.Second
+	backend := l.NewLeakyBucketMemcached(s.memcacheClient, uuid.New().String(), ttl, true)
+	bucket := l.NewLeakyBucket(2, time.Second, l.NewLockNoop(), backend, l.NewSystemClock(), s.logger)
+	ctx := context.Background()
+	_, err := bucket.Limit(ctx)
+	s.Require().NoError(err)
+	_, err = bucket.Limit(ctx)
+	s.Require().NoError(err)
+	state, err := backend.State(ctx)
+	s.Require().NoError(err)
+	s.NotEqual(int64(0), state.Last, "Last should be set after token takes")
+	time.Sleep(ttl + 1500*time.Millisecond)
+
+	state, err = backend.State(ctx)
+	s.Require().NoError(err)
+	s.Equal(int64(0), state.Last, "State should be zero after expiry, got: %+v", state)
+}
+
 func TestLeakyBucket_ZeroCapacity_ReturnsError(t *testing.T) {
 	capacity := int64(0)
 	rate := time.Hour
@@ -241,9 +299,11 @@ func BenchmarkLeakyBuckets(b *testing.B) {
 	s := new(LimitersTestSuite)
 	s.SetT(&testing.T{})
 	s.SetupSuite()
+
 	capacity := int64(1)
 	rate := 100 * time.Millisecond
 	clock := newFakeClock()
+
 	buckets := s.leakyBuckets(capacity, rate, 0, clock)
 	for name, bucket := range buckets {
 		b.Run(name, func(b *testing.B) {
@@ -253,13 +313,15 @@ func BenchmarkLeakyBuckets(b *testing.B) {
 			}
 		})
 	}
+
 	s.TearDownSuite()
 }
 
 // setStateInOldFormat is a test utility method for writing state in the old format to Redis.
 func setStateInOldFormat(ctx context.Context, cli *redis.Client, prefix string, state l.LeakyBucketState, ttl time.Duration) error {
 	_, err := cli.TxPipelined(ctx, func(pipeliner redis.Pipeliner) error {
-		if err := pipeliner.Set(ctx, fmt.Sprintf("{%s}last", prefix), state.Last, ttl).Err(); err != nil {
+		err := pipeliner.Set(ctx, fmt.Sprintf("{%s}last", prefix), state.Last, ttl).Err()
+		if err != nil {
 			return err
 		}
 

--- a/limiters_test.go
+++ b/limiters_test.go
@@ -222,6 +222,7 @@ func (s *LimitersTestSuite) TestLimitContextCancelled() {
 	for n, b := range s.tokenBuckets(capacity, rate, time.Second, clock) {
 		limiters[n] = b
 	}
+
 	for n, b := range s.leakyBuckets(capacity, rate, time.Second, clock) {
 		limiters[n] = b
 	}

--- a/limiters_test.go
+++ b/limiters_test.go
@@ -54,19 +54,23 @@ func (c *fakeClock) Sleep(d time.Duration) {
 	if d == 0 {
 		return
 	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
 	c.t = c.t.Add(d)
 }
 
 func (c *fakeClock) reset() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
 	c.t = c.initial
 }
 
 type LimitersTestSuite struct {
 	suite.Suite
+
 	etcdClient            *clientv3.Client
 	redisClient           *redis.Client
 	redisClusterClient    *redis.ClusterClient
@@ -83,6 +87,7 @@ type LimitersTestSuite struct {
 
 func (s *LimitersTestSuite) SetupSuite() {
 	var err error
+
 	s.etcdClient, err = clientv3.New(clientv3.Config{
 		Endpoints:   strings.Split(os.Getenv("ETCD_ENDPOINTS"), ","),
 		DialTimeout: time.Second,
@@ -126,14 +131,15 @@ func (s *LimitersTestSuite) SetupSuite() {
 
 	s.pgDb, err = sql.Open("postgres", os.Getenv("POSTGRES_URL"))
 	s.Require().NoError(err)
-	s.Require().NoError(s.pgDb.Ping())
+	s.Require().NoError(s.pgDb.PingContext(context.Background()))
 
 	// https://learn.microsoft.com/en-us/azure/cosmos-db/emulator#authentication
 	connString := fmt.Sprintf("AccountEndpoint=http://%s/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==;", os.Getenv("COSMOS_ADDR"))
 	s.cosmosClient, err = azcosmos.NewClientFromConnectionString(connString, &azcosmos.ClientOptions{})
 	s.Require().NoError(err)
 
-	if err = CreateCosmosDBContainer(context.Background(), s.cosmosClient); err != nil {
+	err = CreateCosmosDBContainer(context.Background(), s.cosmosClient)
+	if err != nil {
 		s.Require().ErrorContains(err, "Database 'limiters-db-test' already exists")
 	}
 
@@ -165,6 +171,7 @@ func (s *LimitersTestSuite) lockers(generateKeys bool) map[string]l.DistLocker {
 
 func hash(s string) int64 {
 	h := fnv.New32a()
+
 	_, err := h.Write([]byte(s))
 	if err != nil {
 		panic(err)
@@ -182,6 +189,7 @@ func (s *LimitersTestSuite) distLockers(generateKeys bool) map[string]l.DistLock
 	redisKey := randomKey
 	memcacheKey := randomKey
 	pgKey := randomKey
+
 	if !generateKeys {
 		consulKey = "dist_locker"
 		etcdKey = "dist_locker"
@@ -190,6 +198,7 @@ func (s *LimitersTestSuite) distLockers(generateKeys bool) map[string]l.DistLock
 		memcacheKey = "dist_locker"
 		pgKey = "dist_locker"
 	}
+
 	consulLock, err := s.consulClient.LockKey(consulKey)
 	s.Require().NoError(err)
 
@@ -208,6 +217,7 @@ func (s *LimitersTestSuite) TestLimitContextCancelled() {
 	clock := newFakeClock()
 	capacity := int64(2)
 	rate := time.Second
+
 	limiters := make(map[string]interface{})
 	for n, b := range s.tokenBuckets(capacity, rate, time.Second, clock) {
 		limiters[n] = b
@@ -215,18 +225,23 @@ func (s *LimitersTestSuite) TestLimitContextCancelled() {
 	for n, b := range s.leakyBuckets(capacity, rate, time.Second, clock) {
 		limiters[n] = b
 	}
+
 	for n, w := range s.fixedWindows(capacity, rate, clock) {
 		limiters[n] = w
 	}
+
 	for n, w := range s.slidingWindows(capacity, rate, clock, 1e-9) {
 		limiters[n] = w
 	}
+
 	for n, b := range s.concurrentBuffers(capacity, rate, clock) {
 		limiters[n] = b
 	}
+
 	type rateLimiter interface {
 		Limit(context.Context) (time.Duration, error)
 	}
+
 	type concurrentLimiter interface {
 		Limit(context.Context, string) error
 	}
@@ -234,11 +249,13 @@ func (s *LimitersTestSuite) TestLimitContextCancelled() {
 	for name, limiter := range limiters {
 		s.Run(name, func() {
 			done1 := make(chan struct{})
+
 			go func(limiter interface{}) {
 				defer close(done1)
 				// The context is expired shortly after it is created.
 				ctx, cancel := context.WithCancel(context.Background())
 				cancel()
+
 				switch lim := limiter.(type) {
 				case rateLimiter:
 					_, err := lim.Limit(ctx)
@@ -248,11 +265,16 @@ func (s *LimitersTestSuite) TestLimitContextCancelled() {
 					s.Error(lim.Limit(ctx, "key"), "%T", limiter)
 				}
 			}(limiter)
+
 			done2 := make(chan struct{})
+
 			go func(limiter interface{}) {
 				defer close(done2)
+
 				<-done1
+
 				ctx := context.Background()
+
 				switch lim := limiter.(type) {
 				case rateLimiter:
 					_, err := lim.Limit(ctx)

--- a/locks_test.go
+++ b/locks_test.go
@@ -11,36 +11,46 @@ import (
 
 func (s *LimitersTestSuite) useLock(lock limiters.DistLocker, shared *int, sleep time.Duration) {
 	s.NoError(lock.Lock(context.TODO()))
+
 	sh := *shared
 	// Imitate heavy work...
 	time.Sleep(sleep)
 	// Check for the race condition.
 	s.Equal(sh, *shared)
 	*shared++
+
 	s.NoError(lock.Unlock(context.Background()))
 }
 
 func (s *LimitersTestSuite) TestDistLockers() {
 	locks1 := s.distLockers(false)
+
 	locks2 := s.distLockers(false)
 	for name := range locks1 {
 		s.Run(name, func() {
 			var shared int
+
 			rounds := 6
 			sleep := time.Millisecond * 50
+
 			for i := 0; i < rounds; i++ {
 				wg := sync.WaitGroup{}
 				wg.Add(2)
+
 				go func(k string) {
 					defer wg.Done()
+
 					s.useLock(locks1[k], &shared, sleep)
 				}(name)
 				go func(k string) {
 					defer wg.Done()
+
 					s.useLock(locks2[k], &shared, sleep)
 				}(name)
+
 				wg.Wait()
 			}
+
 			s.Equal(rounds*2, shared)
 		})
 	}
@@ -50,6 +60,7 @@ func BenchmarkDistLockers(b *testing.B) {
 	s := new(LimitersTestSuite)
 	s.SetT(&testing.T{})
 	s.SetupSuite()
+
 	lockers := s.distLockers(false)
 	for name, locker := range lockers {
 		b.Run(name, func(b *testing.B) {
@@ -59,5 +70,6 @@ func BenchmarkDistLockers(b *testing.B) {
 			}
 		})
 	}
+
 	s.TearDownSuite()
 }

--- a/registry.go
+++ b/registry.go
@@ -66,6 +66,7 @@ func NewRegistry() *Registry {
 func (r *Registry) GetOrCreate(key string, value func() interface{}, ttl time.Duration, now time.Time) interface{} {
 	r.mx.Lock()
 	defer r.mx.Unlock()
+
 	item, ok := r.m[key]
 	if ok {
 		// Update the expiration time.
@@ -88,14 +89,18 @@ func (r *Registry) GetOrCreate(key string, value func() interface{}, ttl time.Du
 func (r *Registry) DeleteExpired(now time.Time) int {
 	r.mx.Lock()
 	defer r.mx.Unlock()
+
 	c := 0
+
 	for len(*r.pq) != 0 {
 		item := (*r.pq)[0]
 		if now.Before(item.exp) {
 			break
 		}
+
 		delete(r.m, item.key)
 		heap.Pop(r.pq)
+
 		c++
 	}
 
@@ -106,10 +111,12 @@ func (r *Registry) DeleteExpired(now time.Time) int {
 func (r *Registry) Delete(key string) {
 	r.mx.Lock()
 	defer r.mx.Unlock()
+
 	item, ok := r.m[key]
 	if !ok {
 		return
 	}
+
 	delete(r.m, key)
 	heap.Remove(r.pq, item.index)
 }
@@ -118,6 +125,7 @@ func (r *Registry) Delete(key string) {
 func (r *Registry) Exists(key string) bool {
 	r.mx.Lock()
 	defer r.mx.Unlock()
+
 	_, ok := r.m[key]
 
 	return ok

--- a/registry_test.go
+++ b/registry_test.go
@@ -55,6 +55,7 @@ func TestRegistry_DeleteExpired(t *testing.T) {
 			return newTestingLimiter()
 		}, time.Second*time.Duration(i), clock.Now())
 	}
+
 	clock.Sleep(time.Second * 3)
 	// "touch" the "key3" value that is about to be expired so that its expiration time is extended for 1s.
 	registry.GetOrCreate("key3", func() interface{} {
@@ -62,6 +63,7 @@ func TestRegistry_DeleteExpired(t *testing.T) {
 	}, time.Second, clock.Now())
 
 	assert.Equal(t, 2, registry.DeleteExpired(clock.Now()))
+
 	for i := 1; i <= 10; i++ {
 		if i <= 2 {
 			assert.False(t, registry.Exists(fmt.Sprintf("key%d", i)))
@@ -89,11 +91,13 @@ func TestRegistry_Delete(t *testing.T) {
 func TestRegistry_ConcurrentUsage(t *testing.T) {
 	registry := limiters.NewRegistry()
 	clock := newFakeClock()
+
 	for i := 0; i < 10; i++ {
 		go func(i int) {
 			registry.GetOrCreate(strconv.Itoa(i), func() interface{} { return &struct{}{} }, 0, clock.Now())
 		}(i)
 	}
+
 	for i := 0; i < 10; i++ {
 		go func(i int) {
 			registry.DeleteExpired(clock.Now())

--- a/slidingwindow_test.go
+++ b/slidingwindow_test.go
@@ -297,8 +297,10 @@ func (s *LimitersTestSuite) TestSlidingWindowOverflowAndWait() {
 		for name, bucket := range s.slidingWindows(testCase.capacity, testCase.rate, clock, testCase.epsilon) {
 			s.Run(name, func() {
 				clock.reset()
+
 				for i := 0; i < testCase.requests; i++ {
 					w, err := bucket.Limit(context.TODO())
+
 					s.Require().LessOrEqual(i, len(testCase.results)-1)
 					s.InDelta(testCase.results[i].w, w, testCase.delta, i)
 					s.Equal(testCase.results[i].e, err, i)
@@ -311,6 +313,7 @@ func (s *LimitersTestSuite) TestSlidingWindowOverflowAndWait() {
 
 func (s *LimitersTestSuite) TestSlidingWindowOverflowAndNoWait() {
 	capacity := int64(3)
+
 	clock := newFakeClock()
 	for name, bucket := range s.slidingWindows(capacity, time.Second, clock, 1e-9) {
 		s.Run(name, func() {
@@ -327,12 +330,14 @@ func (s *LimitersTestSuite) TestSlidingWindowOverflowAndNoWait() {
 			// The next request will be the first one to be rejected.
 			w, err := bucket.Limit(context.TODO())
 			s.Require().Equal(l.ErrLimitExhausted, err)
+
 			expected := clock.Now().Add(w)
 
 			// Send a few more requests, all of them should be told to come back at the same time.
 			for i := int64(0); i < capacity; i++ {
 				w, err = bucket.Limit(context.TODO())
 				s.Require().Equal(l.ErrLimitExhausted, err)
+
 				actual := clock.Now().Add(w)
 				s.Require().Equal(expected, actual, i)
 				clock.Sleep(time.Millisecond)
@@ -340,6 +345,7 @@ func (s *LimitersTestSuite) TestSlidingWindowOverflowAndNoWait() {
 
 			// Wait until it is ready.
 			clock.Sleep(expected.Sub(clock.Now()))
+
 			w, err = bucket.Limit(context.TODO())
 			s.Require().NoError(err)
 			s.Require().Equal(time.Duration(0), w)
@@ -351,10 +357,12 @@ func BenchmarkSlidingWindows(b *testing.B) {
 	s := new(LimitersTestSuite)
 	s.SetT(&testing.T{})
 	s.SetupSuite()
+
 	capacity := int64(1)
 	rate := time.Second
 	clock := newFakeClock()
 	epsilon := 1e-9
+
 	windows := s.slidingWindows(capacity, rate, clock, epsilon)
 	for name, window := range windows {
 		b.Run(name, func(b *testing.B) {
@@ -364,5 +372,6 @@ func BenchmarkSlidingWindows(b *testing.B) {
 			}
 		})
 	}
+
 	s.TearDownSuite()
 }

--- a/tokenbucket_test.go
+++ b/tokenbucket_test.go
@@ -174,6 +174,7 @@ func (s *LimitersTestSuite) TestTokenBucketFakeClock() {
 
 func (s *LimitersTestSuite) TestTokenBucketOverflow() {
 	clock := newFakeClock()
+
 	rate := 100 * time.Millisecond
 	for name, bucket := range s.tokenBuckets(2, rate, 0, clock) {
 		s.Run(name, func() {
@@ -200,6 +201,7 @@ func (s *LimitersTestSuite) TestTokenBucketOverflow() {
 
 func (s *LimitersTestSuite) TestTokenTakeMaxOverflow() {
 	clock := newFakeClock()
+
 	rate := 100 * time.Millisecond
 	for name, bucket := range s.tokenBuckets(3, rate, 0, clock) {
 		s.Run(name, func() {
@@ -227,6 +229,7 @@ func (s *LimitersTestSuite) TestTokenTakeMaxOverflow() {
 
 func (s *LimitersTestSuite) TestTokenBucketReset() {
 	clock := newFakeClock()
+
 	rate := 100 * time.Millisecond
 	for name, bucket := range s.tokenBuckets(2, rate, 0, clock) {
 		s.Run(name, func() {
@@ -387,6 +390,7 @@ func BenchmarkTokenBuckets(b *testing.B) {
 	capacity := int64(1)
 	rate := 100 * time.Millisecond
 	clock := newFakeClock()
+
 	buckets := s.tokenBuckets(capacity, rate, 0, clock)
 	for name, bucket := range buckets {
 		b.Run(name, func(b *testing.B) {

--- a/tokenbucket_test.go
+++ b/tokenbucket_test.go
@@ -74,6 +74,7 @@ var tokenBucketUniformTestCases = []struct {
 // tokenBuckets returns all the possible TokenBucket combinations.
 func (s *LimitersTestSuite) tokenBuckets(capacity int64, refillRate, ttl time.Duration, clock l.Clock) map[string]*l.TokenBucket {
 	buckets := make(map[string]*l.TokenBucket)
+
 	for lockerName, locker := range s.lockers(true) {
 		for backendName, backend := range s.tokenBucketBackends(ttl) {
 			buckets[lockerName+":"+backendName] = l.NewTokenBucket(capacity, refillRate, locker, backend, clock, s.logger)
@@ -109,23 +110,32 @@ func (s *LimitersTestSuite) TestTokenBucketRealClock() {
 				wg := sync.WaitGroup{}
 				// mu guards the miss variable below.
 				var mu sync.Mutex
+
 				miss := 0
+
 				for i := int64(0); i < testCase.requestCount; i++ {
 					// No pause for the first request.
 					if i > 0 {
 						clock.Sleep(testCase.requestRate)
 					}
+
 					wg.Add(1)
+
 					go func(bucket *l.TokenBucket) {
 						defer wg.Done()
-						if _, err := bucket.Limit(context.TODO()); err != nil {
+
+						_, err := bucket.Limit(context.TODO())
+						if err != nil {
 							s.Equal(l.ErrLimitExhausted, err, "%T %v", bucket, bucket)
 							mu.Lock()
+
 							miss++
+
 							mu.Unlock()
 						}
 					}(bucket)
 				}
+
 				wg.Wait()
 				s.InDelta(testCase.missExpected, miss, testCase.delta, testCase)
 			})
@@ -139,17 +149,23 @@ func (s *LimitersTestSuite) TestTokenBucketFakeClock() {
 		for name, bucket := range s.tokenBuckets(testCase.capacity, testCase.refillRate, 0, clock) {
 			s.Run(name, func() {
 				clock.reset()
+
 				miss := 0
+
 				for i := int64(0); i < testCase.requestCount; i++ {
 					// No pause for the first request.
 					if i > 0 {
 						clock.Sleep(testCase.requestRate)
 					}
-					if _, err := bucket.Limit(context.TODO()); err != nil {
+
+					_, err := bucket.Limit(context.TODO())
+					if err != nil {
 						s.Equal(l.ErrLimitExhausted, err)
+
 						miss++
 					}
 				}
+
 				s.InDelta(testCase.missExpected, miss, testCase.delta, testCase)
 			})
 		}
@@ -162,6 +178,7 @@ func (s *LimitersTestSuite) TestTokenBucketOverflow() {
 	for name, bucket := range s.tokenBuckets(2, rate, 0, clock) {
 		s.Run(name, func() {
 			clock.reset()
+
 			wait, err := bucket.Limit(context.TODO())
 			s.Require().NoError(err)
 			s.Equal(time.Duration(0), wait)
@@ -214,6 +231,7 @@ func (s *LimitersTestSuite) TestTokenBucketReset() {
 	for name, bucket := range s.tokenBuckets(2, rate, 0, clock) {
 		s.Run(name, func() {
 			clock.reset()
+
 			wait, err := bucket.Limit(context.TODO())
 			s.Require().NoError(err)
 			s.Equal(time.Duration(0), wait)
@@ -224,6 +242,7 @@ func (s *LimitersTestSuite) TestTokenBucketReset() {
 			wait, err = bucket.Limit(context.TODO())
 			s.Require().Equal(l.ErrLimitExhausted, err)
 			s.Equal(rate, wait)
+
 			err = bucket.Reset(context.TODO())
 			s.Require().NoError(err)
 			// Retry the last call.
@@ -267,10 +286,13 @@ func (s *LimitersTestSuite) TestTokenBucketRefill() {
 // setTokenBucketStateInOldFormat is a test utility method for writing state in the old format to Redis.
 func setTokenBucketStateInOldFormat(ctx context.Context, cli *redis.Client, prefix string, state l.TokenBucketState, ttl time.Duration) error {
 	_, err := cli.TxPipelined(ctx, func(pipeliner redis.Pipeliner) error {
-		if err := pipeliner.Set(ctx, fmt.Sprintf("{%s}last", prefix), state.Last, ttl).Err(); err != nil {
+		err := pipeliner.Set(ctx, fmt.Sprintf("{%s}last", prefix), state.Last, ttl).Err()
+		if err != nil {
 			return err
 		}
-		if err := pipeliner.Set(ctx, fmt.Sprintf("{%s}available", prefix), state.Available, ttl).Err(); err != nil {
+
+		err = pipeliner.Set(ctx, fmt.Sprintf("{%s}available", prefix), state.Available, ttl).Err()
+		if err != nil {
 			return err
 		}
 
@@ -361,6 +383,7 @@ func BenchmarkTokenBuckets(b *testing.B) {
 	s := new(LimitersTestSuite)
 	s.SetT(&testing.T{})
 	s.SetupSuite()
+
 	capacity := int64(1)
 	rate := 100 * time.Millisecond
 	clock := newFakeClock()
@@ -373,5 +396,6 @@ func BenchmarkTokenBuckets(b *testing.B) {
 			}
 		})
 	}
+
 	s.TearDownSuite()
 }


### PR DESCRIPTION
Update and fix the linter version at v2.3.1

- Also address all linter issues
- Update golangci/golangci-lint-action version to v2.3.1