### PR TITLE
chore: update Go versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.22', '1.23', '1.24' ]
+        go-version: [ '1.23', '1.24', '1.25' ]
 
     services:
       etcd:

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/mennanov/limiters
 
 go 1.23.8
 
-toolchain go1.24.1
-
 replace github.com/armon/go-metrics => github.com/hashicorp/go-metrics v0.4.1
 
 require (


### PR DESCRIPTION
* 1.22 is no longer supported, as there are dependencies that require Go 1.23.8
* `toolchain` was forcing to run on 1.24, despite using Go 1.22 or 1.23
* [**Go 1.25**](https://go.dev/doc/go1.25) was released lately