### PR TITLE
test: fix flaky TestLeakyBucketNoExpiration on the in-memory backend

### DIFF
--- a/leakybucket_test.go
+++ b/leakybucket_test.go
@@ -163,9 +163,18 @@ func (s *LimitersTestSuite) TestLeakyBucketNoExpiration() {
 	clock := l.NewSystemClock()
 	buckets := s.leakyBuckets(1, time.Minute, 0, clock)
 
-	// Take all capacity from all buckets
+	// Take all capacity from all buckets. A leaky bucket only advances (and persists)
+	// its queue for an admitted request, and the second request per bucket is admitted
+	// only when it lands a non-zero duration after the first. Issue the two rounds in
+	// separate passes with a short sleep in between so the requests get distinct clock
+	// readings: the in-memory backend is otherwise fast enough for back-to-back calls
+	// to share a single SystemClock timestamp, which leaves the bucket under-filled and
+	// makes this test flaky.
 	for _, bucket := range buckets {
 		_, _ = bucket.Limit(context.TODO())
+	}
+	clock.Sleep(time.Millisecond)
+	for _, bucket := range buckets {
 		_, _ = bucket.Limit(context.TODO())
 	}
 

--- a/leakybucket_test.go
+++ b/leakybucket_test.go
@@ -173,7 +173,9 @@ func (s *LimitersTestSuite) TestLeakyBucketNoExpiration() {
 	for _, bucket := range buckets {
 		_, _ = bucket.Limit(context.TODO())
 	}
+
 	clock.Sleep(time.Millisecond)
+
 	for _, bucket := range buckets {
 		_, _ = bucket.Limit(context.TODO())
 	}


### PR DESCRIPTION
## Problem

`TestLeakyBucketNoExpiration/LockNoop:LeakyBucketInMemory` fails reliably on fast machines (and is generally flaky), while passing in CI and under `-race`.

## Root cause

The test fills a capacity-1 leaky bucket with two back-to-back `Limit()` calls, then waits 2s and expects the bucket to still be full.

When both fill calls observe the **same `SystemClock` timestamp** — which the ultra-fast in-memory backend can hit, but the network-backed backends never do because their per-call latency separates the timestamps — the second request computes `wait == rate*capacity` exactly, trips `wait/rate >= capacity`, and returns `ErrLimitExhausted` **before `SetState`**.

That early return is *correct*: a rejected request must not advance (and persist) the queue, otherwise repeated rejections would push `Last` forward indefinitely and permanently lock the bucket out. But it means the stored `Last` never moves past the first call, so after the 2s wait the bucket looks empty and the final `Limit()` is wrongly admitted (`nil` instead of `ErrLimitExhausted`).

This was confirmed deterministically: same-timestamp fills reproduce the failure; distinct-timestamp fills behave correctly.

## Fix

Test-only. Issue the two fill rounds in **separate passes with a short sleep in between**, so each bucket's two requests get distinct clock readings. Production behavior is unchanged.

`TestTokenBucketNoExpiration` fills with a single call (a token bucket consumes its one token in one persisted call) and is structurally unaffected — no change needed.

## Verification

- `TestLeakyBucketNoExpiration` ×10 without `-race` (the condition that failed 3/3 before) → all green.
- In-memory subtest ×3 under `-race` → PASS.
- Sibling `TestLeakyBucketTTLExpiration` → still green (no regression).